### PR TITLE
docs(readme): add build step before npm start

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ MHcCAQEEI...your-key-here...
 ### 4. Start the Server
 
 ```bash
+npm run build
 npm start
 ```
 


### PR DESCRIPTION
Users need to build the project before starting the server.