### PR TITLE
claude/reduce-mcp-context-fFXb6

### DIFF
--- a/.claude/rules/indicators.md
+++ b/.claude/rules/indicators.md
@@ -90,3 +90,4 @@ Before committing, verify all items:
 - [ ] `CLAUDE.md` updated (tool count)
 - [ ] `CoinbaseMcpServer.ts` assist prompt updated (tool count)
 - [ ] All quality checks pass (format, lint, types, knip, coverage)
+- [ ] **If indicator is useful for trading signals**: Add to `TechnicalAnalysisService.ts` (analyze_technical_indicators tool)

--- a/.claude/skills/coinbase-trading/SKILL.md
+++ b/.claude/skills/coinbase-trading/SKILL.md
@@ -45,9 +45,29 @@ The project does NOT need to be built. Just call the tools.
 - **Take-Profit / Stop-Loss**: ATR-based (see "Dynamic Stop-Loss / Take-Profit")
 - **Allowed Pairs**: All EUR trading pairs
 
+### Integrated Analysis Tool (Recommended)
+
+For efficiency, use `analyze_technical_indicators` to fetch candles and compute all indicators in one call:
+
+```
+result = analyze_technical_indicators(
+  productId="BTC-EUR",
+  granularity="ONE_HOUR",
+  candleCount=100,
+  indicators=["rsi", "macd", "bollinger", "adx", "obv", "pivots"]
+)
+```
+
+**Output includes**:
+- `price`: Current, open, high, low, 24h change
+- `indicators`: Computed values for each requested indicator
+- `signal`: Aggregated score (-100 to +100), direction (BUY/SELL/HOLD), confidence (HIGH/MEDIUM/LOW)
+
+This reduces context by ~90-95% compared to calling individual tools.
+
 ### Available Indicator Tools
 
-The MCP server provides 23 technical indicator tools. **Always use these instead of manual calculation:**
+The MCP server provides 24 technical indicator tools. **Always use these instead of manual calculation:**
 
 **Momentum:**
 - `calculate_rsi` - RSI with configurable period
@@ -79,6 +99,7 @@ The MCP server provides 23 technical indicator tools. **Always use these instead
 **Support/Resistance:**
 - `calculate_pivot_points` - 5 types (Standard, Fibonacci, Woodie, Camarilla, DeMark)
 - `calculate_fibonacci_retracement` - Fib levels from swing high/low
+- `detect_swing_points` - Williams Fractal for swing high/low detection
 
 **Patterns:**
 - `detect_candlestick_patterns` - 31 candlestick patterns

--- a/.claude/skills/coinbase-trading/indicators.md
+++ b/.claude/skills/coinbase-trading/indicators.md
@@ -679,6 +679,44 @@ Each type returns a different output structure based on its methodology:
 
 ---
 
+### Swing Points (Williams Fractal)
+
+**MCP Tool**: `detect_swing_points`
+
+**Usage**:
+```
+result = detect_swing_points(candles, fractalPeriod=2)
+```
+
+**Output Structure**:
+```json
+{
+  "fractalPeriod": 2,
+  "swingHigh": {
+    "index": 45,
+    "price": 47500.0,
+    "timestamp": "2024-01-15T10:00:00Z"
+  },
+  "swingLow": {
+    "index": 32,
+    "price": 43200.0,
+    "timestamp": "2024-01-14T22:00:00Z"
+  },
+  "trend": "uptrend",
+  "range": 4300.0
+}
+```
+
+**Interpretation**:
+
+- `trend: "uptrend"`: Recent swing high after swing low → Bullish (+1)
+- `trend: "downtrend"`: Recent swing low after swing high → Bearish (-1)
+- `trend: "sideways"`: No clear direction
+- Use `swingHigh.price` and `swingLow.price` for Fibonacci retracement calculation
+- `range`: Difference between swing high and swing low prices
+
+---
+
 ### Fibonacci Retracement
 
 **MCP Tool**: `calculate_fibonacci_retracement`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Coinbase MCP Server
 
-MCP server with 69 tools (46 Coinbase Advanced Trade API + 23 technical indicators).
+MCP server with 71 tools (46 Coinbase Advanced Trade API + 24 technical indicators + 1 analysis tool).
 
 ## Commands
 
@@ -22,8 +22,9 @@ src/
 ├── server/
 │   ├── CoinbaseMcpServer.ts         # MCP server, tools, SDK integration
 │   ├── TechnicalIndicatorsService.ts # Technical indicator calculations
+│   ├── TechnicalAnalysisService.ts   # Server-side indicator analysis (reduced context)
 │   └── indicators/                   # Manual indicator implementations
-│       └── *.ts                      # Helper functions (e.g., chartPatterns.ts)
+│       └── *.ts                      # Helper functions (e.g., chartPatterns.ts, swingPoints.ts)
 └── test/
     └── serviceMocks.ts               # Test mocks
 ```
@@ -56,7 +57,7 @@ See `.claude/rules/` for context-specific guidelines:
 ```bash
 npm run inspect    # MCP Inspector at http://localhost:6274
                    # Connect to http://localhost:3005/mcp
-                   # Click "List Tools" to see all 69 tools
+                   # Click "List Tools" to see all 71 tools
 ```
 
 ## Code Quality
@@ -72,5 +73,5 @@ npm run test:coverage # Tests with 100% coverage
 ## Resources
 
 - [CONTRIBUTING.md](CONTRIBUTING.md) - Development guide
-- [docs/IMPLEMENTED_TOOLS.md](docs/IMPLEMENTED_TOOLS.md) - All 69 tools
+- [docs/IMPLEMENTED_TOOLS.md](docs/IMPLEMENTED_TOOLS.md) - All 71 tools
 - [Coinbase API Docs](https://docs.cdp.coinbase.com/advanced-trade/)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,640 @@
+# Plan: Integrated Analysis Tool for Context Reduction
+
+## Summary
+
+Introduction of a new MCP tool `analyze_technical_indicators` that combines candle fetching and indicator calculation server-side. This reduces context usage by ~90-95% since candle data never lands in the LLM context.
+
+Additionally, a new `detect_swing_points` tool (Williams Fractals) will be added as both a standalone indicator and as foundation for correct Fibonacci calculation.
+
+## Problem
+
+The `/trade` skill currently performs the following steps:
+
+1. `get_product_candles` → ~100 candles per timeframe/asset (~3k tokens)
+2. `calculate_rsi(candles)` → candles are sent again
+3. `calculate_macd(candles)` → candles are sent again
+4. ... (15+ indicator calls)
+
+**Result**: ~15-60k tokens per analysis cycle
+
+## Solution
+
+New tool `analyze_technical_indicators`:
+- **Input**: productId, granularity, candleCount, indicators (optional)
+- **Internal**: Fetches candles via SDK, calculates indicators
+- **Output**: Only aggregated result values, NO candles
+
+New tool `detect_swing_points`:
+- **Input**: candles, lookback (optional, default: 2)
+- **Output**: Swing highs and swing lows with prices and indices
+- **Used by**: `analyze_technical_indicators` for Fibonacci calculation
+
+---
+
+## Implementation Steps
+
+### Phase 1: Swing Points Indicator (Foundation)
+
+#### 1.1 New Helper: Swing Point Detection
+
+**File**: `src/server/indicators/swingPoints.ts`
+
+Williams Fractal-based swing detection (industry standard):
+
+```typescript
+export interface SwingPoint {
+  index: number;
+  price: number;
+  type: 'high' | 'low';
+}
+
+export interface DetectSwingPointsResponse {
+  swingHighs: SwingPoint[];
+  swingLows: SwingPoint[];
+  latestSwingHigh: SwingPoint | null;
+  latestSwingLow: SwingPoint | null;
+  trend: 'uptrend' | 'downtrend' | 'sideways';
+}
+
+/**
+ * Williams Fractal Definition (Standard: lookback=2, i.e., 5 bars total)
+ *
+ * Swing High: A bar where the high is higher than the highs of
+ *             `lookback` bars before AND `lookback` bars after
+ *
+ * Swing Low:  A bar where the low is lower than the lows of
+ *             `lookback` bars before AND `lookback` bars after
+ */
+export function detectSwingPoints(
+  candles: CandleInput[],
+  lookback: number = 2
+): DetectSwingPointsResponse;
+```
+
+#### 1.2 New Tool: `detect_swing_points`
+
+**File**: Update `src/server/tools/IndicatorToolRegistry.ts`
+
+```typescript
+this.server.registerTool('detect_swing_points', {
+  title: 'Detect Swing Points (Williams Fractals)',
+  description:
+    'Detect swing highs and swing lows using Williams Fractal method. ' +
+    'A swing high occurs when a bar\'s high is higher than the surrounding bars. ' +
+    'A swing low occurs when a bar\'s low is lower than the surrounding bars. ' +
+    'Useful for identifying support/resistance levels, trend direction, and Fibonacci retracement points.',
+  inputSchema: {
+    candles: candlesSchema(5, 'Array of candle data (minimum 5 for default lookback)'),
+    lookback: z.number().int().min(1).max(10).optional()
+      .describe('Number of bars on each side to compare (default: 2, resulting in 5-bar pattern)'),
+  },
+});
+```
+
+### Phase 2: Service Implementation
+
+#### 2.1 New Service: `TechnicalAnalysisService`
+
+**File**: `src/server/TechnicalAnalysisService.ts`
+
+```typescript
+interface AnalyzeTechnicalIndicatorsRequest {
+  productId: string;
+  granularity: Granularity;
+  candleCount?: number; // default: 100
+  indicators?: IndicatorType[]; // optional, default: all
+}
+
+interface AnalyzeTechnicalIndicatorsResponse {
+  productId: string;
+  granularity: string;
+  candleCount: number;
+  timestamp: string;
+  price: {
+    current: number;
+    open: number;
+    high: number;
+    low: number;
+    change24h: number;
+  };
+  indicators: {
+    momentum?: MomentumIndicators;
+    trend?: TrendIndicators;
+    volatility?: VolatilityIndicators;
+    volume?: VolumeIndicators;
+    patterns?: PatternIndicators;
+    supportResistance?: SupportResistanceIndicators;
+  };
+  signal: {
+    score: number; // -100 to +100
+    direction: 'STRONG_BUY' | 'BUY' | 'NEUTRAL' | 'SELL' | 'STRONG_SELL';
+    confidence: 'HIGH' | 'MEDIUM' | 'LOW';
+  };
+}
+```
+
+**Dependencies**:
+- `ProductsService` (for `getProductCandlesFixed`)
+- `TechnicalIndicatorsService` (for calculations)
+
+#### 2.2 Pivot Points: Correct Implementation
+
+**Requirement**: Daily OHLC from previous trading day (industry standard)
+
+```typescript
+async analyzeTechnicalIndicators(request: AnalyzeTechnicalIndicatorsRequest) {
+  // 1. Fetch requested candles (e.g., 15m)
+  const candles = await this.productsService.getProductCandlesFixed({
+    productId: request.productId,
+    granularity: request.granularity,
+    start: ...,
+    end: ...,
+  });
+
+  // 2. For Pivot Points: Fetch Daily candles (additional API call)
+  if (this.shouldCalculatePivotPoints(request.indicators)) {
+    const dailyCandles = await this.productsService.getProductCandlesFixed({
+      productId: request.productId,
+      granularity: 'ONE_DAY',
+      start: this.getTwoDaysAgo(),
+      end: this.getToday(),
+    });
+
+    // Use previous trading day (index 1, not current day)
+    const previousDay = dailyCandles[1];
+    pivotPoints = this.indicators.calculatePivotPoints({
+      high: previousDay.high,
+      low: previousDay.low,
+      close: previousDay.close,
+      open: previousDay.open,
+    });
+  }
+
+  // 3. For Fibonacci: Use fractal-based swing detection
+  if (this.shouldCalculateFibonacci(request.indicators)) {
+    const swings = detectSwingPoints(candles);
+
+    if (swings.latestSwingHigh && swings.latestSwingLow) {
+      fibonacci = this.indicators.calculateFibonacciRetracement({
+        start: swings.trend === 'uptrend'
+          ? swings.latestSwingLow.price
+          : swings.latestSwingHigh.price,
+        end: swings.trend === 'uptrend'
+          ? swings.latestSwingHigh.price
+          : swings.latestSwingLow.price,
+      });
+    }
+  }
+}
+```
+
+#### 2.3 Define Indicator Types
+
+**File**: `src/server/TechnicalAnalysis.ts` (Types)
+
+All 24 indicator tools supported (23 existing + 1 new):
+
+```typescript
+type IndicatorType =
+  // Momentum (7)
+  | 'rsi' | 'macd' | 'stochastic' | 'adx' | 'cci' | 'williams_r' | 'roc'
+  // Trend (4)
+  | 'sma' | 'ema' | 'ichimoku' | 'psar'
+  // Volatility (3)
+  | 'bollinger_bands' | 'atr' | 'keltner'
+  // Volume (4)
+  | 'obv' | 'mfi' | 'vwap' | 'volume_profile'
+  // Pattern Detection (4) - includes new swing_points
+  | 'candlestick_patterns' | 'rsi_divergence' | 'chart_patterns' | 'swing_points'
+  // Support/Resistance (2)
+  | 'pivot_points' | 'fibonacci';
+
+interface MomentumIndicators {
+  rsi?: { value: number; signal: string };
+  macd?: { macd: number; signal: number; histogram: number; crossover: string };
+  stochastic?: { k: number; d: number; signal: string };
+  adx?: { adx: number; pdi: number; mdi: number; trendStrength: string };
+  cci?: { value: number; signal: string };
+  williamsR?: { value: number; signal: string };
+  roc?: { value: number; signal: string };
+}
+
+interface TrendIndicators {
+  sma?: { value: number; trend: string };
+  ema?: { value: number; trend: string };
+  ichimoku?: { tenkan: number; kijun: number; senkouA: number; senkouB: number; signal: string };
+  psar?: { value: number; trend: string };
+}
+
+interface VolatilityIndicators {
+  bollingerBands?: { upper: number; middle: number; lower: number; percentB: number; signal: string };
+  atr?: { value: number; volatility: string };
+  keltner?: { upper: number; middle: number; lower: number; signal: string };
+}
+
+interface VolumeIndicators {
+  obv?: { value: number; trend: string };
+  mfi?: { value: number; signal: string };
+  vwap?: { value: number; position: string };
+  volumeProfile?: { poc: number; valueAreaHigh: number; valueAreaLow: number };
+}
+
+interface PatternIndicators {
+  candlestickPatterns?: { patterns: string[]; bias: string };
+  rsiDivergence?: { type: string | null; strength: string | null };
+  chartPatterns?: { patterns: string[]; direction: string | null };
+  swingPoints?: {
+    latestSwingHigh: number | null;
+    latestSwingLow: number | null;
+    trend: string;
+    swingHighCount: number;
+    swingLowCount: number;
+  };
+}
+
+interface SupportResistanceIndicators {
+  pivotPoints?: {
+    pivot: number;
+    r1: number; r2: number; r3: number;
+    s1: number; s2: number; s3: number;
+    source: 'daily'; // Always from daily candles
+  };
+  fibonacci?: {
+    trend: string;
+    levels: Record<string, number>;
+    swingHigh: number;
+    swingLow: number;
+  };
+}
+```
+
+### Phase 3: Tool Registration
+
+#### 3.1 New ToolRegistry: `AnalysisToolRegistry`
+
+**File**: `src/server/tools/AnalysisToolRegistry.ts`
+
+- Registers `analyze_technical_indicators` tool
+- Uses `TechnicalAnalysisService`
+- Zod schema for input validation
+
+### Phase 4: Server Integration
+
+#### 4.1 Update CoinbaseMcpServer.ts
+
+- Instantiate `TechnicalAnalysisService`
+- Register `AnalysisToolRegistry`
+- Update tool count in assist prompt (69 → 71)
+
+### Phase 5: Tests
+
+#### 5.1 Unit Tests for Swing Points
+
+**File**: `src/server/indicators/swingPoints.spec.ts`
+
+Tests:
+- `should detect swing highs with default lookback`
+- `should detect swing lows with default lookback`
+- `should detect swing points with custom lookback`
+- `should return empty arrays when no swings found`
+- `should identify uptrend when latest swing low is before latest swing high`
+- `should identify downtrend when latest swing high is before latest swing low`
+- `should handle minimum candle count`
+- `should handle edge cases (all equal prices)`
+
+#### 5.2 Unit Tests for TechnicalAnalysisService
+
+**File**: `src/server/TechnicalAnalysisService.spec.ts`
+
+Tests:
+- `should analyze technicals with default indicators`
+- `should analyze technicals with specific indicators`
+- `should return correct signal direction for bullish data`
+- `should return correct signal direction for bearish data`
+- `should handle insufficient candle data gracefully`
+- `should use default candleCount when not specified`
+- `should calculate price summary correctly`
+- `should include all momentum indicators when requested`
+- `should include all trend indicators when requested`
+- `should include all volatility indicators when requested`
+- `should include all volume indicators when requested`
+- `should include all pattern indicators when requested`
+- `should include swing points when requested`
+- `should fetch daily candles for pivot points calculation`
+- `should calculate pivot points from previous trading day`
+- `should use swing points for fibonacci calculation`
+- `should determine fibonacci trend from swing point positions`
+
+#### 5.3 Integration Tests for AnalysisToolRegistry
+
+**File**: `src/server/tools/AnalysisToolRegistry.spec.ts`
+
+Tests:
+- `should register analyze_technical_indicators tool`
+- `should call service with correct parameters`
+- `should return formatted response`
+- `should handle service errors`
+
+### Phase 6: Documentation
+
+#### 6.1 docs/IMPLEMENTED_TOOLS.md
+
+- Add `detect_swing_points` to "Technical Indicators" section (now 24)
+- Add new section "Technical Analysis (1)" for `analyze_technical_indicators`
+- Update total tool count (69 → 71)
+
+#### 6.2 README.md
+
+- Update tool count in features section (69 → 71)
+- Brief mention of the new tools
+
+#### 6.3 CLAUDE.md
+
+- Update tool count (69 → 71)
+
+#### 6.4 .claude/rules/indicators.md
+
+- Add step to checklist: "Update `analyze_technical_indicators` if adding new indicator"
+- Document that new indicators must be supported by both:
+  1. Individual `calculate_*` / `detect_*` tool
+  2. `analyze_technical_indicators` aggregated tool
+
+#### 6.5 .claude/skills/coinbase-trading/SKILL.md
+
+- Update section "2. Collect Market Data":
+  - New tool `analyze_technical_indicators` as primary method
+  - Document legacy workflow (individual tools) as alternative
+- Update section "3. Technical Analysis":
+  - Note integrated calculation via `analyze_technical_indicators`
+  - Reduce manual indicator calls
+  - Document `detect_swing_points` as standalone tool for:
+    - Identifying support/resistance levels
+    - Finding Fibonacci retracement points manually
+    - Trend direction analysis
+
+#### 6.6 .claude/skills/coinbase-trading/indicators.md
+
+- Add documentation for `detect_swing_points`
+- Note about `analyze_technical_indicators` for bundled calculation
+
+---
+
+## Files Overview
+
+### New Files
+
+| File | Description |
+|------|-------------|
+| `src/server/indicators/swingPoints.ts` | Williams Fractal swing detection |
+| `src/server/indicators/swingPoints.spec.ts` | Tests for swing detection |
+| `src/server/TechnicalAnalysis.ts` | Type definitions for analysis |
+| `src/server/TechnicalAnalysisService.ts` | Service for integrated analysis |
+| `src/server/TechnicalAnalysisService.spec.ts` | Unit tests for service |
+| `src/server/tools/AnalysisToolRegistry.ts` | Tool registration |
+| `src/server/tools/AnalysisToolRegistry.spec.ts` | Tests for tool registry |
+
+### Files to Modify
+
+| File | Changes |
+|------|---------|
+| `src/server/TechnicalIndicatorsService.ts` | Add `detectSwingPoints` method |
+| `src/server/tools/IndicatorToolRegistry.ts` | Register `detect_swing_points` tool |
+| `src/server/CoinbaseMcpServer.ts` | Service + Registry integration, tool count |
+| `docs/IMPLEMENTED_TOOLS.md` | Document new tools, count |
+| `README.md` | Update tool count |
+| `CLAUDE.md` | Update tool count |
+| `.claude/rules/indicators.md` | Add requirement to update `analyze_technical_indicators` |
+| `.claude/skills/coinbase-trading/SKILL.md` | Switch workflow to new tool |
+| `.claude/skills/coinbase-trading/indicators.md` | Document new tools |
+
+---
+
+## Acceptance Criteria
+
+### Functional Criteria
+
+- [ ] **AC-01**: Tool `analyze_technical_indicators` is callable via MCP
+- [ ] **AC-02**: Tool accepts parameters: `productId`, `granularity`, `candleCount`, `indicators`
+- [ ] **AC-03**: Response contains NO raw candle data
+- [ ] **AC-04**: Response contains all requested indicator values
+- [ ] **AC-05**: Response contains aggregated signal (score, direction, confidence)
+- [ ] **AC-06**: Response contains price summary (current, open, high, low, change24h)
+- [ ] **AC-07**: When `indicators: undefined`, ALL 24 indicators are calculated
+- [ ] **AC-08**: When `candleCount: undefined`, 100 candles are used
+- [ ] **AC-09**: Invalid inputs are rejected with meaningful error messages
+- [ ] **AC-10**: All 24 indicators are supported:
+  - Momentum: rsi, macd, stochastic, adx, cci, williams_r, roc
+  - Trend: sma, ema, ichimoku, psar
+  - Volatility: bollinger_bands, atr, keltner
+  - Volume: obv, mfi, vwap, volume_profile
+  - Patterns: candlestick_patterns, rsi_divergence, chart_patterns, swing_points
+  - S/R: pivot_points, fibonacci
+
+### Pivot Points Criteria (Industry Standard)
+
+- [ ] **AC-11**: Pivot points are calculated from Daily candles (not requested timeframe)
+- [ ] **AC-12**: Pivot points use previous trading day's OHLC (not current day)
+- [ ] **AC-13**: Additional API call is made for daily candles when pivot_points requested
+- [ ] **AC-14**: Response includes `source: 'daily'` to indicate data source
+
+### Fibonacci Criteria (Industry Standard)
+
+- [ ] **AC-15**: Fibonacci uses Williams Fractal swing detection (not absolute min/max)
+- [ ] **AC-16**: Swing detection uses configurable lookback (default: 2 bars each side)
+- [ ] **AC-17**: Trend is determined by which swing point occurred more recently
+- [ ] **AC-18**: Response includes `swingHigh` and `swingLow` prices used
+- [ ] **AC-19**: Response includes detected `trend` (uptrend/downtrend)
+
+### Swing Points Tool Criteria
+
+- [ ] **AC-20**: Tool `detect_swing_points` is callable via MCP
+- [ ] **AC-21**: Tool accepts parameters: `candles`, `lookback` (optional)
+- [ ] **AC-22**: Response contains arrays of swing highs and swing lows
+- [ ] **AC-23**: Each swing point includes `index`, `price`, and `type`
+- [ ] **AC-24**: Response includes `latestSwingHigh` and `latestSwingLow`
+- [ ] **AC-25**: Response includes detected `trend`
+- [ ] **AC-26**: Tool follows same patterns as other `detect_*` tools (naming, schema, response structure)
+- [ ] **AC-27**: Tool is documented in ALL relevant documentation (same as other indicator tools):
+  - `docs/IMPLEMENTED_TOOLS.md` (Technical Indicators section)
+  - `.claude/skills/coinbase-trading/indicators.md`
+  - `.claude/skills/coinbase-trading/SKILL.md`
+
+### Industry Standard Compliance (CRITICAL)
+
+**WARNING**: These tools handle real money. Simplified or incorrect calculations can lead to financial losses.
+
+- [ ] **AC-28**: ALL indicator calculations (existing and new) follow industry-standard formulas
+- [ ] **AC-29**: No simplifications or approximations that could affect trading decisions
+- [ ] **AC-30**: Williams Fractal implementation matches standard definition (5-bar pattern with configurable lookback)
+- [ ] **AC-31**: Pivot Points always use daily OHLC from previous trading day (never intraday data)
+- [ ] **AC-32**: Fibonacci Retracement uses proper swing detection (never absolute min/max)
+- [ ] **AC-33**: All existing 23 indicator tools continue to use correct industry-standard calculations
+
+### Quality Criteria
+
+- [ ] **AC-34**: `npm run test:coverage` shows 100% coverage in all categories
+- [ ] **AC-35**: `npm run lint` shows no errors/warnings
+- [ ] **AC-36**: `npm run test:types` shows no errors/warnings
+- [ ] **AC-37**: `npm run knip` shows no unused exports/dependencies
+- [ ] **AC-38**: `npm run format` was executed before commit
+
+### Test Structure Consistency
+
+- [ ] **AC-39**: Tests for `detect_swing_points` follow same patterns as existing indicator tool tests
+- [ ] **AC-40**: Tests for `analyze_technical_indicators` follow same patterns as existing service tests
+- [ ] **AC-41**: Test file structure matches existing conventions:
+  - Helper functions colocated in `src/server/indicators/*.spec.ts`
+  - Service tests in `src/server/*.spec.ts`
+  - Tool registry tests follow existing registry test patterns
+- [ ] **AC-42**: Test descriptions use same style as existing tests (behavioral, user-perspective)
+- [ ] **AC-43**: Mock patterns match `serviceMocks.ts` conventions
+
+### Documentation Criteria
+
+- [ ] **AC-44**: `docs/IMPLEMENTED_TOOLS.md` contains both new tools with descriptions
+- [ ] **AC-45**: `docs/IMPLEMENTED_TOOLS.md` shows correct tool count (71)
+- [ ] **AC-46**: `README.md` shows correct tool count
+- [ ] **AC-47**: `CLAUDE.md` shows correct tool count
+- [ ] **AC-48**: `.claude/rules/indicators.md` documents requirement to update `analyze_technical_indicators`
+- [ ] **AC-49**: `SKILL.md` documents usage of `analyze_technical_indicators`
+- [ ] **AC-50**: `SKILL.md` shows reduced workflow (fewer tool calls)
+- [ ] **AC-51**: `SKILL.md` documents `detect_swing_points` as standalone alternative
+- [ ] **AC-52**: `indicators.md` documents `detect_swing_points` tool
+
+### Backward Compatibility
+
+- [ ] **AC-53**: All existing 69 tools continue to work unchanged
+- [ ] **AC-54**: Existing tests for other tools remain green
+
+### Context Reduction (Validation)
+
+- [ ] **AC-55**: Response size of `analyze_technical_indicators` is < 3KB (vs. ~15KB with individual calls)
+- [ ] **AC-56**: Response contains `candleCount` but not the candles themselves
+
+---
+
+## Commit Format
+
+```text
+feat(analysis): add analyze_technical_indicators and detect_swing_points tools
+
+- Add swingPoints.ts with Williams Fractal swing detection
+- Add TechnicalAnalysis.ts with type definitions for all 24 indicators
+- Add TechnicalAnalysisService for integrated candle + indicator analysis
+- Add AnalysisToolRegistry for MCP tool registration
+- Add detect_swing_points tool to IndicatorToolRegistry
+- Update CoinbaseMcpServer to include new tools (71 tools total)
+- Implement industry-standard pivot points (from daily candles)
+- Implement industry-standard fibonacci (from fractal swing points)
+- Update .claude/rules/indicators.md with requirement to extend new tool
+- Update SKILL.md workflow to use analyze_technical_indicators
+- Update docs/IMPLEMENTED_TOOLS.md with new tools
+- Update README.md and CLAUDE.md tool counts
+- Add comprehensive tests with 100% coverage
+
+Reduces context usage by ~90-95% by keeping candle data server-side
+and only returning computed indicator values to the LLM.
+```
+
+---
+
+## Execution Order
+
+1. **Create swing points helper** (`src/server/indicators/swingPoints.ts`)
+2. **Write swing points tests** (`src/server/indicators/swingPoints.spec.ts`)
+3. **Add detectSwingPoints to TechnicalIndicatorsService**
+4. **Register detect_swing_points tool** (`IndicatorToolRegistry.ts`)
+5. **Create types** (`TechnicalAnalysis.ts`)
+6. **Implement service** (`TechnicalAnalysisService.ts`)
+7. **Write service tests** (`TechnicalAnalysisService.spec.ts`)
+8. **Create tool registry** (`AnalysisToolRegistry.ts`)
+9. **Write tool registry tests** (`AnalysisToolRegistry.spec.ts`)
+10. **Server integration** (`CoinbaseMcpServer.ts`)
+11. **Run quality checks**:
+    - `npm run format`
+    - `npm run lint`
+    - `npm run test:types`
+    - `npm run test:coverage`
+    - `npm run knip`
+12. **Update documentation**:
+    - `docs/IMPLEMENTED_TOOLS.md`
+    - `README.md`
+    - `CLAUDE.md`
+    - `.claude/rules/indicators.md`
+    - `.claude/skills/coinbase-trading/SKILL.md`
+    - `.claude/skills/coinbase-trading/indicators.md`
+13. **Final quality checks**
+14. **Create commit**
+
+---
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Complex service dependencies | Use dependency injection |
+| Indicator calculation may fail | Graceful degradation with partial results |
+| Response might still be large | Only `latestValue` per indicator, no arrays |
+| Breaking changes in skill | Document legacy workflow as alternative |
+| Future indicators forgotten | Update `.claude/rules/indicators.md` checklist |
+| Daily candle API call fails | Return pivot_points as null with error info |
+| No swing points detected | Return fibonacci as null with explanation |
+
+---
+
+## Estimated Response Size
+
+**Before (individual tools)**:
+- `get_product_candles`: ~3000 tokens (100 candles)
+- `calculate_rsi`: ~200 tokens
+- `calculate_macd`: ~300 tokens
+- ... × 15 indicators = ~15,000 tokens
+
+**After (analyze_technical_indicators)**:
+- Single response: ~1000-1500 tokens (slightly larger due to S/R metadata)
+- **Savings: ~90-93%**
+
+---
+
+## Indicator Coverage Matrix
+
+| Category | Count | Indicators |
+|----------|-------|------------|
+| Momentum | 7 | rsi, macd, stochastic, adx, cci, williams_r, roc |
+| Trend | 4 | sma, ema, ichimoku, psar |
+| Volatility | 3 | bollinger_bands, atr, keltner |
+| Volume | 4 | obv, mfi, vwap, volume_profile |
+| Patterns | 4 | candlestick_patterns, rsi_divergence, chart_patterns, **swing_points** |
+| Support/Resistance | 2 | pivot_points (daily), fibonacci (swing-based) |
+| **Total** | **24** | All indicators with industry-standard calculations |
+
+---
+
+## Technical Details: Industry Standard Compliance
+
+### Pivot Points
+
+| Aspect | Implementation |
+|--------|----------------|
+| Data Source | Daily OHLC (separate API call) |
+| Period | Previous trading day |
+| Calculation | Standard pivot formula (configurable: Standard, Fibonacci, Woodie, Camarilla, DeMark) |
+| Response Metadata | `source: 'daily'` indicates data origin |
+
+### Fibonacci Retracement
+
+| Aspect | Implementation |
+|--------|----------------|
+| Swing Detection | Williams Fractal (5-bar pattern by default) |
+| Lookback | Configurable (default: 2 bars each side) |
+| Trend Detection | Based on which swing point occurred more recently |
+| Response Metadata | `swingHigh`, `swingLow`, `trend` included |
+
+### Williams Fractal (Swing Points)
+
+| Aspect | Implementation |
+|--------|----------------|
+| Pattern | 5-bar pattern (2 bars each side by default) |
+| Swing High | Bar high > highs of `lookback` bars before AND after |
+| Swing Low | Bar low < lows of `lookback` bars before AND after |
+| Configurable | `lookback` parameter (1-10) |

--- a/README.md
+++ b/README.md
@@ -138,11 +138,11 @@ Add the MCP server to your Claude settings (e.g., `~/.claude/settings.json`):
 }
 ```
 
-Now you can use all 46 trading tools and the `/coinbase:assist` prompt in Claude, but without the autonomous `/trade` skill.
+Now you can use all 71 tools (46 Coinbase API + 24 indicators + 1 analysis) and the `/coinbase:assist` prompt in Claude, but without the autonomous `/trade` skill.
 
 ## Features
 
-### 46 Trading Tools & Autonomous Trading Skill
+### 71 Tools: Trading, Indicators & Analysis
 
 Full access to the Coinbase Advanced Trading API **plus a fully autonomous trading skill for Claude**:
 
@@ -183,7 +183,7 @@ A built-in Claude command that runs an autonomous trading bot:
 
 **What it does:**
 
-- Technical analysis: 20+ indicators across 6 weighted categories (Momentum 25%, Trend 30%, Volatility 15%, Volume 15%, S/R 10%, Patterns 5%)
+- Technical analysis: 24 indicators across 6 weighted categories (Momentum 25%, Trend 30%, Volatility 15%, Volume 15%, S/R 10%, Patterns 5%)
 - Sentiment analysis (Fear & Greed Index with 7 regions, news search)
 - Automatic order execution with preview
 - Dynamic ATR-based stop-loss/take-profit
@@ -258,7 +258,7 @@ coinbase-mcp-server/
 ├── src/
 │   ├── index.ts                 # HTTP server entry point
 │   └── server/
-│       └── CoinbaseMcpServer.ts # MCP server with 63 tools
+│       └── CoinbaseMcpServer.ts # MCP server with 71 tools
 ├── .claude/
 │   ├── settings.json            # MCP server config (auto-loaded)
 │   └── commands/
@@ -271,7 +271,7 @@ coinbase-mcp-server/
 
 ```bash
 npm start          # Start production server
-npm run dev        # Start with hot-reload
+npm run start:dev  # Start with hot-reload
 npm test           # Run tests
 npm run lint       # Check code style
 npm run build      # Build for production
@@ -280,10 +280,10 @@ npm run inspect    # Open MCP Inspector for debugging
 
 ### Testing with MCP Inspector
 
-1. Start the server: `npm run dev`
+1. Start the server: `npm run start:dev`
 2. In another terminal: `npm run inspect`
 3. Connect to `http://localhost:3005/mcp`
-4. Test any of the 63 tools interactively
+4. Test any of the 71 tools interactively
 
 ---
 

--- a/docs/IMPLEMENTED_TOOLS.md
+++ b/docs/IMPLEMENTED_TOOLS.md
@@ -4,7 +4,7 @@
 
 This server now uses the official `@coinbase-sample/advanced-trade-sdk-ts` SDK directly, eliminating all custom domain/repository layers.
 
-**Total Tools: 69**
+**Total Tools: 71**
 
 ## Accounts (2)
 
@@ -85,7 +85,7 @@ This server now uses the official `@coinbase-sample/advanced-trade-sdk-ts` SDK d
 
 - ✅ `get_api_key_permissions` - Get current API key permissions
 
-## Technical Indicators (23)
+## Technical Indicators (24)
 
 - ✅ `calculate_rsi` - Calculate RSI (Relative Strength Index)
 - ✅ `calculate_macd` - Calculate MACD (Moving Average Convergence Divergence)
@@ -110,3 +110,8 @@ This server now uses the official `@coinbase-sample/advanced-trade-sdk-ts` SDK d
 - ✅ `calculate_pivot_points` - Calculate Pivot Points (Standard, Fibonacci, Woodie, Camarilla, DeMark)
 - ✅ `detect_rsi_divergence` - Detect RSI Divergence (bullish, bearish, hidden)
 - ✅ `detect_chart_patterns` - Detect chart patterns (Double Top/Bottom, Head & Shoulders, Triangles, Flags)
+- ✅ `detect_swing_points` - Detect swing highs/lows using Williams Fractal (5-bar pattern)
+
+## Analysis Tools (1)
+
+- ✅ `analyze_technical_indicators` - Calculate multiple indicators server-side, reducing context usage by ~90-95%. Fetches candles and returns computed values, aggregated signals, and price summary

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2985,7 +2984,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3093,7 +3091,6 @@
       "integrity": "sha512-okqtOgqu2qmZJ5iN4TWlgfF171dZmx2FzdOv2K/ixL2LZWDStL8+JgQerI2sa8eAEfoydG9+0V96m7V+P8yE1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.52.0",
@@ -3123,7 +3120,6 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -3341,7 +3337,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3486,7 +3481,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
       "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -3715,7 +3709,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4488,7 +4481,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4549,7 +4541,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4901,7 +4892,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6012,7 +6002,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7067,7 +7056,6 @@
       "integrity": "sha512-esPk+8Qvx/f0bzI7YelUeZp+jCtFOk3KjZ7s9iBQZ6HlymSXoTtWGiIRZP05/9Oy2ehIoIjenVwndxGtxOIJYQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "globby": "15.0.0",
         "js-yaml": "4.1.1",
@@ -8327,7 +8315,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8626,7 +8613,6 @@
       "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9313,8 +9299,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -9392,7 +9377,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9709,7 +9693,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/server/CoinbaseMcpServer.spec.ts
+++ b/src/server/CoinbaseMcpServer.spec.ts
@@ -18,6 +18,7 @@ import {
   mockPublicService,
   mockDataService,
   mockTechnicalIndicatorsService,
+  mockTechnicalAnalysisService,
   mockServices,
 } from '@test/serviceMocks';
 import { Granularity } from './ProductCandles';
@@ -1625,6 +1626,132 @@ describe('CoinbaseMcpServer Integration Tests', () => {
           expect(
             mockTechnicalIndicatorsService.calculateFibonacciRetracement,
           ).toHaveBeenCalledWith(args);
+          expectResponseToContain(response, result);
+        });
+      });
+
+      describe('detect_swing_points', () => {
+        it('should call detectSwingPoints via MCP tool detect_swing_points', async () => {
+          const args = {
+            candles: [
+              {
+                open: '100',
+                high: '105',
+                low: '95',
+                close: '102',
+                volume: '1000',
+              },
+              {
+                open: '102',
+                high: '108',
+                low: '100',
+                close: '105',
+                volume: '1100',
+              },
+              {
+                open: '105',
+                high: '112',
+                low: '103',
+                close: '110',
+                volume: '1200',
+              },
+              {
+                open: '110',
+                high: '115',
+                low: '108',
+                close: '107',
+                volume: '1300',
+              },
+              {
+                open: '107',
+                high: '110',
+                low: '104',
+                close: '105',
+                volume: '1400',
+              },
+            ],
+            lookback: 2,
+          };
+          const result = {
+            swingHighs: [{ index: 2, price: 112, type: 'high' as const }],
+            swingLows: [],
+            latestSwingHigh: { index: 2, price: 112, type: 'high' as const },
+            latestSwingLow: null,
+            trend: 'sideways' as const,
+          };
+          mockTechnicalIndicatorsService.detectSwingPoints.mockReturnValueOnce(
+            result,
+          );
+
+          const response = await client.callTool({
+            name: 'detect_swing_points',
+            arguments: args,
+          });
+
+          expect(
+            mockTechnicalIndicatorsService.detectSwingPoints,
+          ).toHaveBeenCalledWith(args);
+          expectResponseToContain(response, result);
+        });
+      });
+
+      describe('analyze_technical_indicators', () => {
+        it('should call analyzeTechnicalIndicators via MCP tool analyze_technical_indicators', async () => {
+          const args = {
+            productId: 'BTC-USD',
+            granularity: 'ONE_HOUR',
+            candleCount: 100,
+            indicators: ['rsi', 'macd'],
+          };
+          const result = {
+            productId: 'BTC-USD',
+            granularity: 'ONE_HOUR',
+            candleCount: 100,
+            timestamp: '2024-01-15T12:00:00Z',
+            price: {
+              current: 105,
+              open: 100,
+              high: 110,
+              low: 95,
+              change24h: 5,
+            },
+            indicators: {
+              momentum: {
+                rsi: {
+                  value: 55,
+                  signal: 'neutral',
+                },
+                macd: {
+                  macd: 1.5,
+                  signal: 1.2,
+                  histogram: 0.3,
+                  crossover: 'bullish',
+                },
+              },
+            },
+            signal: {
+              score: 25,
+              direction: 'BUY' as const,
+              confidence: 'MEDIUM' as const,
+            },
+          };
+          mockTechnicalAnalysisService.analyzeTechnicalIndicators.mockResolvedValueOnce(
+            result,
+          );
+
+          const response = await client.callTool({
+            name: 'analyze_technical_indicators',
+            arguments: args,
+          });
+
+          expect(
+            mockTechnicalAnalysisService.analyzeTechnicalIndicators,
+          ).toHaveBeenCalledWith({
+            productId: 'BTC-USD',
+            granularity: 'ONE_HOUR',
+            candleCount: 100,
+            indicators: ['rsi', 'macd'],
+          });
           expectResponseToContain(response, result);
         });
       });

--- a/src/server/TechnicalAnalysis.ts
+++ b/src/server/TechnicalAnalysis.ts
@@ -1,0 +1,503 @@
+/**
+ * Technical Analysis type definitions.
+ *
+ * Defines all types for the analyze_technical_indicators tool which
+ * provides integrated candle fetching and indicator calculation.
+ */
+
+import { Granularity } from './ProductCandles';
+
+/**
+ * All supported indicator types (24 total).
+ *
+ * Categories:
+ * - Momentum (7): rsi, macd, stochastic, adx, cci, williams_r, roc
+ * - Trend (4): sma, ema, ichimoku, psar
+ * - Volatility (3): bollinger_bands, atr, keltner
+ * - Volume (4): obv, mfi, vwap, volume_profile
+ * - Patterns (4): candlestick_patterns, rsi_divergence, chart_patterns, swing_points
+ * - Support/Resistance (2): pivot_points, fibonacci
+ */
+export enum IndicatorType {
+  // Momentum (7)
+  RSI = 'rsi',
+  MACD = 'macd',
+  STOCHASTIC = 'stochastic',
+  ADX = 'adx',
+  CCI = 'cci',
+  WILLIAMS_R = 'williams_r',
+  ROC = 'roc',
+  // Trend (4)
+  SMA = 'sma',
+  EMA = 'ema',
+  ICHIMOKU = 'ichimoku',
+  PSAR = 'psar',
+  // Volatility (3)
+  BOLLINGER_BANDS = 'bollinger_bands',
+  ATR = 'atr',
+  KELTNER = 'keltner',
+  // Volume (4)
+  OBV = 'obv',
+  MFI = 'mfi',
+  VWAP = 'vwap',
+  VOLUME_PROFILE = 'volume_profile',
+  // Pattern Detection (4)
+  CANDLESTICK_PATTERNS = 'candlestick_patterns',
+  RSI_DIVERGENCE = 'rsi_divergence',
+  CHART_PATTERNS = 'chart_patterns',
+  SWING_POINTS = 'swing_points',
+  // Support/Resistance (2)
+  PIVOT_POINTS = 'pivot_points',
+  FIBONACCI = 'fibonacci',
+}
+
+/**
+ * Request input for analyze_technical_indicators tool.
+ */
+export interface AnalyzeTechnicalIndicatorsRequest {
+  /** Product ID (e.g., "BTC-USD") */
+  readonly productId: string;
+  /** Candle granularity (e.g., FIFTEEN_MINUTE, ONE_HOUR) */
+  readonly granularity: Granularity;
+  /** Number of candles to fetch (default: 100) */
+  readonly candleCount?: number;
+  /** Specific indicators to calculate (default: all 24) */
+  readonly indicators?: readonly IndicatorType[];
+}
+
+/**
+ * Signal direction based on indicator analysis.
+ */
+export type SignalDirection =
+  | 'STRONG_BUY'
+  | 'BUY'
+  | 'NEUTRAL'
+  | 'SELL'
+  | 'STRONG_SELL';
+
+/**
+ * Confidence level of the signal.
+ */
+export type SignalConfidence = 'HIGH' | 'MEDIUM' | 'LOW';
+
+/**
+ * Aggregated signal from all calculated indicators.
+ */
+export interface AggregatedSignal {
+  /** Score from -100 (strong sell) to +100 (strong buy) */
+  readonly score: number;
+  /** Direction interpretation of the score */
+  readonly direction: SignalDirection;
+  /** Confidence based on indicator agreement */
+  readonly confidence: SignalConfidence;
+}
+
+/**
+ * Price summary for the analyzed period.
+ */
+export interface PriceSummary {
+  /** Current (latest) price */
+  readonly current: number;
+  /** Open price of the period */
+  readonly open: number;
+  /** Highest price in the period */
+  readonly high: number;
+  /** Lowest price in the period */
+  readonly low: number;
+  /** 24-hour price change percentage */
+  readonly change24h: number;
+}
+
+// ============================================================================
+// Indicator Result Types
+// ============================================================================
+
+/**
+ * RSI indicator result.
+ */
+export interface RsiResult {
+  /** RSI value (0-100) */
+  readonly value: number;
+  /** Signal interpretation (overbought, neutral, oversold) */
+  readonly signal: string;
+}
+
+/**
+ * MACD indicator result.
+ */
+export interface MacdResult {
+  /** MACD line value */
+  readonly macd: number;
+  /** Signal line value */
+  readonly signal: number;
+  /** Histogram value (MACD - Signal) */
+  readonly histogram: number;
+  /** Crossover status (bullish, bearish, none) */
+  readonly crossover: string;
+}
+
+/**
+ * Stochastic oscillator result.
+ */
+export interface StochasticResult {
+  /** %K fast line value */
+  readonly k: number;
+  /** %D signal line value */
+  readonly d: number;
+  /** Signal interpretation */
+  readonly signal: string;
+}
+
+/**
+ * ADX (Average Directional Index) result.
+ */
+export interface AdxResult {
+  /** ADX value */
+  readonly adx: number;
+  /** Positive directional indicator */
+  readonly pdi: number;
+  /** Negative directional indicator */
+  readonly mdi: number;
+  /** Trend strength (strong, weak, none) */
+  readonly trendStrength: string;
+}
+
+/**
+ * CCI (Commodity Channel Index) result.
+ */
+export interface CciResult {
+  /** CCI value */
+  readonly value: number;
+  /** Signal interpretation */
+  readonly signal: string;
+}
+
+/**
+ * Williams %R result.
+ */
+export interface WilliamsRResult {
+  /** Williams %R value (-100 to 0) */
+  readonly value: number;
+  /** Signal interpretation */
+  readonly signal: string;
+}
+
+/**
+ * ROC (Rate of Change) result.
+ */
+export interface RocResult {
+  /** ROC percentage value */
+  readonly value: number;
+  /** Signal interpretation */
+  readonly signal: string;
+}
+
+/**
+ * Momentum indicators grouped result.
+ */
+export interface MomentumIndicators {
+  rsi?: RsiResult;
+  macd?: MacdResult;
+  stochastic?: StochasticResult;
+  adx?: AdxResult;
+  cci?: CciResult;
+  williamsR?: WilliamsRResult;
+  roc?: RocResult;
+}
+
+/**
+ * SMA (Simple Moving Average) result.
+ */
+export interface SmaResult {
+  /** SMA value */
+  readonly value: number;
+  /** Trend based on price vs SMA */
+  readonly trend: string;
+}
+
+/**
+ * EMA (Exponential Moving Average) result.
+ */
+export interface EmaResult {
+  /** EMA value */
+  readonly value: number;
+  /** Trend based on price vs EMA */
+  readonly trend: string;
+}
+
+/**
+ * Ichimoku Cloud result.
+ */
+export interface IchimokuResult {
+  /** Tenkan-sen (conversion line) */
+  readonly tenkan: number;
+  /** Kijun-sen (base line) */
+  readonly kijun: number;
+  /** Senkou Span A (leading span A) */
+  readonly senkouA: number;
+  /** Senkou Span B (leading span B) */
+  readonly senkouB: number;
+  /** Signal interpretation */
+  readonly signal: string;
+}
+
+/**
+ * Parabolic SAR result.
+ */
+export interface PsarResult {
+  /** PSAR value */
+  readonly value: number;
+  /** Trend direction (up, down) */
+  readonly trend: string;
+}
+
+/**
+ * Trend indicators grouped result.
+ */
+export interface TrendIndicators {
+  sma?: SmaResult;
+  ema?: EmaResult;
+  ichimoku?: IchimokuResult;
+  psar?: PsarResult;
+}
+
+/**
+ * Bollinger Bands result.
+ */
+export interface BollingerBandsResult {
+  /** Upper band value */
+  readonly upper: number;
+  /** Middle band (SMA) value */
+  readonly middle: number;
+  /** Lower band value */
+  readonly lower: number;
+  /** %B value (position within bands) */
+  readonly percentB: number;
+  /** Signal interpretation */
+  readonly signal: string;
+}
+
+/**
+ * ATR (Average True Range) result.
+ */
+export interface AtrResult {
+  /** ATR value */
+  readonly value: number;
+  /** Volatility level (high, normal, low) */
+  readonly volatility: string;
+}
+
+/**
+ * Keltner Channels result.
+ */
+export interface KeltnerResult {
+  /** Upper channel value */
+  readonly upper: number;
+  /** Middle channel (EMA) value */
+  readonly middle: number;
+  /** Lower channel value */
+  readonly lower: number;
+  /** Signal interpretation */
+  readonly signal: string;
+}
+
+/**
+ * Volatility indicators grouped result.
+ */
+export interface VolatilityIndicators {
+  bollingerBands?: BollingerBandsResult;
+  atr?: AtrResult;
+  keltner?: KeltnerResult;
+}
+
+/**
+ * OBV (On-Balance Volume) result.
+ */
+export interface ObvResult {
+  /** OBV value */
+  readonly value: number;
+  /** Trend based on OBV direction */
+  readonly trend: string;
+}
+
+/**
+ * MFI (Money Flow Index) result.
+ */
+export interface MfiResult {
+  /** MFI value (0-100) */
+  readonly value: number;
+  /** Signal interpretation */
+  readonly signal: string;
+}
+
+/**
+ * VWAP (Volume Weighted Average Price) result.
+ */
+export interface VwapResult {
+  /** VWAP value */
+  readonly value: number;
+  /** Price position relative to VWAP */
+  readonly position: string;
+}
+
+/**
+ * Volume Profile result.
+ */
+export interface VolumeProfileResult {
+  /** Point of Control (highest volume price) */
+  readonly poc: number;
+  /** Value Area High */
+  readonly valueAreaHigh: number;
+  /** Value Area Low */
+  readonly valueAreaLow: number;
+}
+
+/**
+ * Volume indicators grouped result.
+ */
+export interface VolumeIndicators {
+  obv?: ObvResult;
+  mfi?: MfiResult;
+  vwap?: VwapResult;
+  volumeProfile?: VolumeProfileResult;
+}
+
+/**
+ * Candlestick patterns result.
+ */
+export interface CandlestickPatternsResult {
+  /** Detected pattern names */
+  readonly patterns: readonly string[];
+  /** Overall bias (bullish, bearish, neutral) */
+  readonly bias: string;
+}
+
+/**
+ * RSI Divergence result.
+ */
+export interface RsiDivergenceResult {
+  /** Divergence type (bullish, bearish, hidden_bullish, hidden_bearish, null) */
+  readonly type: string | null;
+  /** Divergence strength (weak, medium, strong, null) */
+  readonly strength: string | null;
+}
+
+/**
+ * Chart patterns result.
+ */
+export interface ChartPatternsResult {
+  /** Detected pattern names */
+  readonly patterns: readonly string[];
+  /** Overall direction (bullish, bearish, null) */
+  readonly direction: string | null;
+}
+
+/**
+ * Swing points result.
+ */
+export interface SwingPointsResult {
+  /** Latest swing high price */
+  readonly latestSwingHigh: number | null;
+  /** Latest swing low price */
+  readonly latestSwingLow: number | null;
+  /** Detected trend (uptrend, downtrend, sideways) */
+  readonly trend: string;
+  /** Number of swing highs detected */
+  readonly swingHighCount: number;
+  /** Number of swing lows detected */
+  readonly swingLowCount: number;
+}
+
+/**
+ * Pattern detection indicators grouped result.
+ */
+export interface PatternIndicators {
+  candlestickPatterns?: CandlestickPatternsResult;
+  rsiDivergence?: RsiDivergenceResult;
+  chartPatterns?: ChartPatternsResult;
+  swingPoints?: SwingPointsResult;
+}
+
+/**
+ * Pivot Points result.
+ */
+export interface PivotPointsResult {
+  /** Central pivot point */
+  readonly pivot: number;
+  /** Resistance level 1 */
+  readonly r1: number;
+  /** Resistance level 2 */
+  readonly r2: number;
+  /** Resistance level 3 */
+  readonly r3: number;
+  /** Support level 1 */
+  readonly s1: number;
+  /** Support level 2 */
+  readonly s2: number;
+  /** Support level 3 */
+  readonly s3: number;
+  /** Data source (always 'daily' for industry standard) */
+  readonly source: 'daily';
+}
+
+/**
+ * Fibonacci retracement result.
+ */
+export interface FibonacciResult {
+  /** Detected trend used for calculation */
+  readonly trend: string;
+  /** Retracement and extension levels */
+  readonly levels: Readonly<Record<string, number>>;
+  /** Swing high price used */
+  readonly swingHigh: number;
+  /** Swing low price used */
+  readonly swingLow: number;
+}
+
+/**
+ * Support/Resistance indicators grouped result.
+ */
+export interface SupportResistanceIndicators {
+  pivotPoints?: PivotPointsResult;
+  fibonacci?: FibonacciResult;
+}
+
+/**
+ * All indicators grouped by category.
+ */
+export interface IndicatorResults {
+  momentum?: MomentumIndicators;
+  trend?: TrendIndicators;
+  volatility?: VolatilityIndicators;
+  volume?: VolumeIndicators;
+  patterns?: PatternIndicators;
+  supportResistance?: SupportResistanceIndicators;
+}
+
+/**
+ * Response from analyze_technical_indicators tool.
+ *
+ * Contains:
+ * - Metadata (productId, granularity, candleCount, timestamp)
+ * - Price summary (current, open, high, low, change24h)
+ * - Calculated indicators grouped by category
+ * - Aggregated signal (score, direction, confidence)
+ *
+ * Does NOT contain raw candle data to minimize context usage.
+ */
+export interface AnalyzeTechnicalIndicatorsResponse {
+  /** Product ID that was analyzed */
+  readonly productId: string;
+  /** Granularity used for candles */
+  readonly granularity: string;
+  /** Number of candles analyzed */
+  readonly candleCount: number;
+  /** ISO 8601 timestamp of analysis */
+  readonly timestamp: string;
+  /** Price summary for the period */
+  readonly price: PriceSummary;
+  /** Calculated indicator results */
+  readonly indicators: IndicatorResults;
+  /** Aggregated trading signal */
+  readonly signal: AggregatedSignal;
+}

--- a/src/server/TechnicalAnalysisService.spec.ts
+++ b/src/server/TechnicalAnalysisService.spec.ts
@@ -1,0 +1,3245 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { TechnicalAnalysisService } from './TechnicalAnalysisService';
+import type { ProductsService } from './ProductsService';
+import type {
+  TechnicalIndicatorsService,
+  CandleInput,
+} from './TechnicalIndicatorsService';
+import { Granularity } from './ProductCandles';
+import { IndicatorType } from './TechnicalAnalysis';
+
+describe('TechnicalAnalysisService', () => {
+  let service: TechnicalAnalysisService;
+  let mockProductsService: jest.Mocked<ProductsService>;
+  let mockIndicatorsService: jest.Mocked<TechnicalIndicatorsService>;
+
+  const createMockCandles = (
+    count: number,
+    options?: { closePrice?: number },
+  ): CandleInput[] => {
+    return Array.from({ length: count }, (_, i) => ({
+      open: (100 + i).toString(),
+      high: (102 + i).toString(),
+      low: (98 + i).toString(),
+      close:
+        i === 0 && options?.closePrice !== undefined
+          ? options.closePrice.toString()
+          : (101 + i).toString(),
+      volume: '1000',
+    }));
+  };
+
+  beforeEach(() => {
+    mockProductsService = {
+      getProductCandlesFixed: jest.fn(),
+    } as unknown as jest.Mocked<ProductsService>;
+
+    mockIndicatorsService = {
+      calculateRsi: jest.fn(),
+      calculateMacd: jest.fn(),
+      calculateSma: jest.fn(),
+      calculateEma: jest.fn(),
+      calculateBollingerBands: jest.fn(),
+      calculateAtr: jest.fn(),
+      calculateStochastic: jest.fn(),
+      calculateAdx: jest.fn(),
+      calculateObv: jest.fn(),
+      calculateVwap: jest.fn(),
+      calculateCci: jest.fn(),
+      calculateWilliamsR: jest.fn(),
+      calculateRoc: jest.fn(),
+      calculateMfi: jest.fn(),
+      calculatePsar: jest.fn(),
+      calculateIchimokuCloud: jest.fn(),
+      calculateKeltnerChannels: jest.fn(),
+      calculateFibonacciRetracement: jest.fn(),
+      detectCandlestickPatterns: jest.fn(),
+      calculateVolumeProfile: jest.fn(),
+      calculatePivotPoints: jest.fn(),
+      detectRsiDivergence: jest.fn(),
+      detectChartPatterns: jest.fn(),
+      detectSwingPoints: jest.fn(),
+    } as unknown as jest.Mocked<TechnicalIndicatorsService>;
+
+    service = new TechnicalAnalysisService(
+      mockProductsService,
+      mockIndicatorsService,
+    );
+  });
+
+  describe('analyzeTechnicalIndicators', () => {
+    it('should fetch candles and calculate requested indicators', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateRsi.mockReturnValue({
+        period: 14,
+        values: [45, 50, 55],
+        latestValue: 55,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.RSI],
+      });
+
+      expect(mockProductsService.getProductCandlesFixed).toHaveBeenCalled();
+      expect(mockIndicatorsService.calculateRsi).toHaveBeenCalled();
+      expect(result.productId).toBe('BTC-USD');
+      expect(result.granularity).toBe(Granularity.ONE_HOUR);
+      expect(result.indicators.momentum?.rsi).toBeDefined();
+    });
+
+    it('should use default candle count of 100', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+      mockIndicatorsService.calculateRsi.mockReturnValue({
+        period: 14,
+        values: [55],
+        latestValue: 55,
+      });
+
+      await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.FIFTEEN_MINUTE,
+        indicators: [IndicatorType.RSI],
+      });
+
+      // Should request candles for approximately 100 periods
+      expect(mockProductsService.getProductCandlesFixed).toHaveBeenCalledWith(
+        expect.objectContaining({
+          productId: 'BTC-USD',
+          granularity: Granularity.FIFTEEN_MINUTE,
+        }),
+      );
+    });
+
+    it('should calculate all indicators when none specified', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      // Set up mocks for all indicators
+      mockIndicatorsService.calculateRsi.mockReturnValue({
+        period: 14,
+        values: [55],
+        latestValue: 55,
+      });
+      mockIndicatorsService.calculateMacd.mockReturnValue({
+        fastPeriod: 12,
+        slowPeriod: 26,
+        signalPeriod: 9,
+        values: [{ MACD: 1.5, signal: 1.0, histogram: 0.5 }],
+        latestValue: { MACD: 1.5, signal: 1.0, histogram: 0.5 },
+      });
+      mockIndicatorsService.calculateSma.mockReturnValue({
+        period: 20,
+        values: [100],
+        latestValue: 100,
+      });
+      mockIndicatorsService.calculateEma.mockReturnValue({
+        period: 20,
+        values: [100],
+        latestValue: 100,
+      });
+      mockIndicatorsService.calculateBollingerBands.mockReturnValue({
+        period: 20,
+        stdDev: 2,
+        values: [
+          { middle: 100, upper: 110, lower: 90, pb: 0.5, bandwidth: 0.2 },
+        ],
+        latestValue: {
+          middle: 100,
+          upper: 110,
+          lower: 90,
+          pb: 0.5,
+          bandwidth: 0.2,
+        },
+      });
+      mockIndicatorsService.calculateAtr.mockReturnValue({
+        period: 14,
+        values: [5],
+        latestValue: 5,
+      });
+      mockIndicatorsService.calculateStochastic.mockReturnValue({
+        kPeriod: 14,
+        dPeriod: 3,
+        values: [{ k: 60, d: 55 }],
+        latestValue: { k: 60, d: 55 },
+      });
+      mockIndicatorsService.calculateAdx.mockReturnValue({
+        period: 14,
+        values: [{ adx: 25, pdi: 30, mdi: 20 }],
+        latestValue: { adx: 25, pdi: 30, mdi: 20 },
+      });
+      mockIndicatorsService.calculateObv.mockReturnValue({
+        values: [1000, 1100],
+        latestValue: 1100,
+      });
+      mockIndicatorsService.calculateVwap.mockReturnValue({
+        values: [100],
+        latestValue: 100,
+      });
+      mockIndicatorsService.calculateCci.mockReturnValue({
+        period: 20,
+        values: [50],
+        latestValue: 50,
+      });
+      mockIndicatorsService.calculateWilliamsR.mockReturnValue({
+        period: 14,
+        values: [-50],
+        latestValue: -50,
+      });
+      mockIndicatorsService.calculateRoc.mockReturnValue({
+        period: 12,
+        values: [5],
+        latestValue: 5,
+      });
+      mockIndicatorsService.calculateMfi.mockReturnValue({
+        period: 14,
+        values: [50],
+        latestValue: 50,
+      });
+      mockIndicatorsService.calculatePsar.mockReturnValue({
+        step: 0.02,
+        max: 0.2,
+        values: [99],
+        latestValue: 99,
+      });
+      mockIndicatorsService.calculateIchimokuCloud.mockReturnValue({
+        conversionPeriod: 9,
+        basePeriod: 26,
+        spanPeriod: 52,
+        displacement: 26,
+        values: [
+          { conversion: 100, base: 99, spanA: 100, spanB: 98, chikou: 101 },
+        ],
+        latestValue: {
+          conversion: 100,
+          base: 99,
+          spanA: 100,
+          spanB: 98,
+          chikou: 101,
+        },
+      });
+      mockIndicatorsService.calculateKeltnerChannels.mockReturnValue({
+        maPeriod: 20,
+        atrPeriod: 10,
+        multiplier: 2,
+        useSMA: false,
+        values: [{ middle: 100, upper: 110, lower: 90 }],
+        latestValue: { middle: 100, upper: 110, lower: 90 },
+      });
+      mockIndicatorsService.detectCandlestickPatterns.mockReturnValue({
+        bullish: true,
+        bearish: false,
+        patterns: [],
+        detectedPatterns: ['Hammer'],
+      });
+      mockIndicatorsService.detectRsiDivergence.mockReturnValue({
+        rsiPeriod: 14,
+        lookbackPeriod: 14,
+        rsiValues: [55],
+        divergences: [],
+        latestDivergence: null,
+        hasBullishDivergence: false,
+        hasBearishDivergence: false,
+      });
+      mockIndicatorsService.detectChartPatterns.mockReturnValue({
+        lookbackPeriod: 50,
+        patterns: [],
+        bullishPatterns: [],
+        bearishPatterns: [],
+        latestPattern: null,
+      });
+      mockIndicatorsService.detectSwingPoints.mockReturnValue({
+        swingHighs: [{ index: 10, price: 110, type: 'high' as const }],
+        swingLows: [{ index: 5, price: 95, type: 'low' as const }],
+        latestSwingHigh: { index: 10, price: 110, type: 'high' as const },
+        latestSwingLow: { index: 5, price: 95, type: 'low' as const },
+        trend: 'uptrend' as const,
+      });
+      mockIndicatorsService.calculateVolumeProfile.mockReturnValue({
+        noOfBars: 12,
+        zones: [
+          {
+            rangeStart: 95,
+            rangeEnd: 105,
+            bullishVolume: 500,
+            bearishVolume: 400,
+            totalVolume: 900,
+          },
+        ],
+        pointOfControl: {
+          rangeStart: 100,
+          rangeEnd: 105,
+          bullishVolume: 500,
+          bearishVolume: 400,
+          totalVolume: 900,
+        },
+        valueAreaHigh: 110,
+        valueAreaLow: 90,
+      });
+      mockIndicatorsService.calculatePivotPoints.mockReturnValue({
+        type: 'standard',
+        pivotPoint: 100,
+        resistance1: 105,
+        resistance2: 110,
+        resistance3: 115,
+        support1: 95,
+        support2: 90,
+        support3: 85,
+      });
+      mockIndicatorsService.calculateFibonacciRetracement.mockReturnValue({
+        start: 95,
+        end: 110,
+        trend: 'uptrend',
+        levels: [
+          { level: 0, price: 95 },
+          { level: 23.6, price: 98.54 },
+          { level: 38.2, price: 100.73 },
+          { level: 50, price: 102.5 },
+          { level: 61.8, price: 104.27 },
+        ],
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+      });
+
+      expect(result.indicators.momentum).toBeDefined();
+      expect(result.indicators.trend).toBeDefined();
+      expect(result.indicators.volatility).toBeDefined();
+      expect(result.indicators.volume).toBeDefined();
+      expect(result.indicators.patterns).toBeDefined();
+    });
+
+    it('should return price summary from candle data', async () => {
+      const mockCandles: CandleInput[] = [
+        { open: '100', high: '110', low: '95', close: '105', volume: '1000' },
+        { open: '95', high: '105', low: '90', close: '100', volume: '800' },
+        { open: '90', high: '100', low: '85', close: '95', volume: '600' },
+      ];
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [],
+      });
+
+      expect(result.price.current).toBe(105); // Latest close
+      expect(result.price.open).toBe(90); // Oldest open
+      expect(result.price.high).toBe(110); // Highest high
+      expect(result.price.low).toBe(85); // Lowest low
+    });
+
+    it('should return aggregated signal with score and direction', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateRsi.mockReturnValue({
+        period: 14,
+        values: [25],
+        latestValue: 25, // Oversold - bullish
+      });
+      mockIndicatorsService.calculateMacd.mockReturnValue({
+        fastPeriod: 12,
+        slowPeriod: 26,
+        signalPeriod: 9,
+        values: [
+          { MACD: 0.5, signal: 1.0, histogram: -0.5 },
+          { MACD: 1.5, signal: 1.0, histogram: 0.5 },
+        ],
+        latestValue: { MACD: 1.5, signal: 1.0, histogram: 0.5 },
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.RSI, IndicatorType.MACD],
+      });
+
+      expect(result.signal).toBeDefined();
+      expect(result.signal.score).toBeGreaterThanOrEqual(-100);
+      expect(result.signal.score).toBeLessThanOrEqual(100);
+      expect(['STRONG_BUY', 'BUY', 'NEUTRAL', 'SELL', 'STRONG_SELL']).toContain(
+        result.signal.direction,
+      );
+      expect(['HIGH', 'MEDIUM', 'LOW']).toContain(result.signal.confidence);
+    });
+
+    it('should not include raw candles in response', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [],
+      });
+
+      // Response should NOT contain candles property
+      expect(
+        (result as unknown as { candles: unknown }).candles,
+      ).toBeUndefined();
+      // But should contain candleCount
+      expect(result.candleCount).toBe(100);
+    });
+
+    it('should handle empty candle response', async () => {
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: [],
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [],
+      });
+
+      expect(result.candleCount).toBe(0);
+      expect(result.price.current).toBe(0);
+      expect(result.price.open).toBe(0);
+    });
+
+    it('should fetch daily candles for pivot points', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed
+        .mockResolvedValueOnce({ candles: mockCandles }) // Main candles
+        .mockResolvedValueOnce({
+          candles: [
+            {
+              open: '100',
+              high: '110',
+              low: '95',
+              close: '105',
+              volume: '1000',
+            },
+            { open: '95', high: '105', low: '90', close: '100', volume: '800' },
+            { open: '90', high: '100', low: '85', close: '95', volume: '600' },
+          ],
+        }); // Daily candles
+
+      mockIndicatorsService.calculatePivotPoints.mockReturnValue({
+        type: 'standard',
+        pivotPoint: 100,
+        resistance1: 105,
+        resistance2: 110,
+        resistance3: 115,
+        support1: 95,
+        support2: 90,
+        support3: 85,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.PIVOT_POINTS],
+      });
+
+      // Should have called getProductCandlesFixed twice
+      expect(mockProductsService.getProductCandlesFixed).toHaveBeenCalledTimes(
+        2,
+      );
+      // Second call should be for daily candles
+      expect(
+        mockProductsService.getProductCandlesFixed,
+      ).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          granularity: Granularity.ONE_DAY,
+        }),
+      );
+      expect(result.indicators.supportResistance?.pivotPoints).toBeDefined();
+      expect(result.indicators.supportResistance?.pivotPoints?.source).toBe(
+        'daily',
+      );
+    });
+
+    it('should use swing points for Fibonacci calculation', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.detectSwingPoints.mockReturnValue({
+        swingHighs: [{ index: 80, price: 150, type: 'high' as const }],
+        swingLows: [{ index: 20, price: 100, type: 'low' as const }],
+        latestSwingHigh: { index: 80, price: 150, type: 'high' as const },
+        latestSwingLow: { index: 20, price: 100, type: 'low' as const },
+        trend: 'uptrend' as const,
+      });
+      mockIndicatorsService.calculateFibonacciRetracement.mockReturnValue({
+        start: 100,
+        end: 150,
+        trend: 'uptrend',
+        levels: [
+          { level: 0, price: 100 },
+          { level: 38.2, price: 119.1 },
+          { level: 50, price: 125 },
+          { level: 61.8, price: 130.9 },
+          { level: 100, price: 150 },
+        ],
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.FIBONACCI],
+      });
+
+      expect(mockIndicatorsService.detectSwingPoints).toHaveBeenCalled();
+      expect(
+        mockIndicatorsService.calculateFibonacciRetracement,
+      ).toHaveBeenCalledWith({
+        start: 100, // Swing low for uptrend
+        end: 150, // Swing high for uptrend
+      });
+      expect(result.indicators.supportResistance?.fibonacci).toBeDefined();
+      expect(result.indicators.supportResistance?.fibonacci?.swingHigh).toBe(
+        150,
+      );
+      expect(result.indicators.supportResistance?.fibonacci?.swingLow).toBe(
+        100,
+      );
+    });
+
+    it('should limit candle count to maximum of 300', async () => {
+      const mockCandles = createMockCandles(300);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        candleCount: 500, // Requesting more than max
+        indicators: [],
+      });
+
+      // The time range calculation should be based on 300, not 500
+      const call = mockProductsService.getProductCandlesFixed.mock.calls[0][0];
+      const start = new Date(call.start).getTime();
+      const end = new Date(call.end).getTime();
+      const durationMs = end - start;
+      const expectedDuration = 300 * 3600 * 1000; // 300 hours in ms
+
+      // Should be approximately 300 hours
+      expect(durationMs).toBeLessThanOrEqual(expectedDuration + 1000);
+    });
+
+    it('should enforce minimum candle count of 5', async () => {
+      const mockCandles = createMockCandles(5);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        candleCount: 1, // Requesting less than min
+        indicators: [],
+      });
+
+      const call = mockProductsService.getProductCandlesFixed.mock.calls[0][0];
+      const start = new Date(call.start).getTime();
+      const end = new Date(call.end).getTime();
+      const durationMs = end - start;
+      const expectedDuration = 5 * 3600 * 1000; // 5 hours in ms
+
+      // Should be at least 5 hours
+      expect(durationMs).toBeGreaterThanOrEqual(expectedDuration - 1000);
+    });
+
+    it('should include timestamp in response', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      const beforeCall = new Date().toISOString();
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [],
+      });
+      const afterCall = new Date().toISOString();
+
+      expect(result.timestamp).toBeDefined();
+      expect(result.timestamp >= beforeCall).toBe(true);
+      expect(result.timestamp <= afterCall).toBe(true);
+    });
+  });
+
+  describe('signal interpretation', () => {
+    it('should interpret RSI overbought (>=70) as bearish', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateRsi.mockReturnValue({
+        period: 14,
+        values: [75],
+        latestValue: 75,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.RSI],
+      });
+
+      expect(result.indicators.momentum?.rsi?.signal).toBe('overbought');
+    });
+
+    it('should interpret RSI oversold (<=30) as bullish', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateRsi.mockReturnValue({
+        period: 14,
+        values: [25],
+        latestValue: 25,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.RSI],
+      });
+
+      expect(result.indicators.momentum?.rsi?.signal).toBe('oversold');
+    });
+
+    it('should detect MACD bullish crossover', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateMacd.mockReturnValue({
+        fastPeriod: 12,
+        slowPeriod: 26,
+        signalPeriod: 9,
+        values: [
+          { MACD: 0.5, signal: 1.0, histogram: -0.5 }, // Previous: MACD below signal
+          { MACD: 1.5, signal: 1.0, histogram: 0.5 }, // Current: MACD above signal
+        ],
+        latestValue: { MACD: 1.5, signal: 1.0, histogram: 0.5 },
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.MACD],
+      });
+
+      expect(result.indicators.momentum?.macd?.crossover).toBe('bullish');
+    });
+
+    it('should interpret ADX strong trend (>=25)', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateAdx.mockReturnValue({
+        period: 14,
+        values: [{ adx: 30, pdi: 35, mdi: 20 }],
+        latestValue: { adx: 30, pdi: 35, mdi: 20 },
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.ADX],
+      });
+
+      expect(result.indicators.momentum?.adx?.trendStrength).toBe('strong');
+    });
+
+    it('should detect MACD bearish crossover', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateMacd.mockReturnValue({
+        fastPeriod: 12,
+        slowPeriod: 26,
+        signalPeriod: 9,
+        values: [
+          { MACD: 1.5, signal: 1.0, histogram: 0.5 }, // Previous: MACD above signal
+          { MACD: 0.5, signal: 1.0, histogram: -0.5 }, // Current: MACD below signal
+        ],
+        latestValue: { MACD: 0.5, signal: 1.0, histogram: -0.5 },
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.MACD],
+      });
+
+      expect(result.indicators.momentum?.macd?.crossover).toBe('bearish');
+    });
+
+    it('should interpret Stochastic oversold as bullish', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateStochastic.mockReturnValue({
+        kPeriod: 14,
+        dPeriod: 3,
+        values: [{ k: 15, d: 18 }],
+        latestValue: { k: 15, d: 18 },
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.STOCHASTIC],
+      });
+
+      expect(result.indicators.momentum?.stochastic?.signal).toBe('oversold');
+    });
+
+    it('should interpret Stochastic overbought as bearish', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateStochastic.mockReturnValue({
+        kPeriod: 14,
+        dPeriod: 3,
+        values: [{ k: 85, d: 82 }],
+        latestValue: { k: 85, d: 82 },
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.STOCHASTIC],
+      });
+
+      expect(result.indicators.momentum?.stochastic?.signal).toBe('overbought');
+    });
+
+    it('should interpret ADX with MDI > PDI as bearish signal', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateAdx.mockReturnValue({
+        period: 14,
+        values: [{ adx: 30, pdi: 20, mdi: 35 }],
+        latestValue: { adx: 30, pdi: 20, mdi: 35 },
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.ADX],
+      });
+
+      expect(result.indicators.momentum?.adx?.mdi).toBe(35);
+      expect(result.indicators.momentum?.adx?.pdi).toBe(20);
+    });
+
+    it('should interpret CCI oversold (<-100) as bullish', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateCci.mockReturnValue({
+        period: 20,
+        values: [-150],
+        latestValue: -150,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.CCI],
+      });
+
+      expect(result.indicators.momentum?.cci?.signal).toBe('oversold');
+    });
+
+    it('should interpret CCI overbought (>100) as bearish', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateCci.mockReturnValue({
+        period: 20,
+        values: [150],
+        latestValue: 150,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.CCI],
+      });
+
+      expect(result.indicators.momentum?.cci?.signal).toBe('overbought');
+    });
+
+    it('should interpret Williams %R oversold (<-80) as bullish', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateWilliamsR.mockReturnValue({
+        period: 14,
+        values: [-90],
+        latestValue: -90,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.WILLIAMS_R],
+      });
+
+      expect(result.indicators.momentum?.williamsR?.signal).toBe('oversold');
+    });
+
+    it('should interpret Williams %R overbought (>-20) as bearish', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateWilliamsR.mockReturnValue({
+        period: 14,
+        values: [-10],
+        latestValue: -10,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.WILLIAMS_R],
+      });
+
+      expect(result.indicators.momentum?.williamsR?.signal).toBe('overbought');
+    });
+
+    it('should interpret ROC positive as bullish', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateRoc.mockReturnValue({
+        period: 12,
+        values: [5.5],
+        latestValue: 5.5,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.ROC],
+      });
+
+      expect(result.indicators.momentum?.roc?.signal).toBe('bullish');
+    });
+
+    it('should interpret ROC negative as bearish', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateRoc.mockReturnValue({
+        period: 12,
+        values: [-5.5],
+        latestValue: -5.5,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.ROC],
+      });
+
+      expect(result.indicators.momentum?.roc?.signal).toBe('bearish');
+    });
+
+    it('should interpret SMA price above as bullish trend', async () => {
+      // Set close price above SMA (150 > 100)
+      const mockCandles = createMockCandles(100, { closePrice: 150 });
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateSma.mockReturnValue({
+        period: 20,
+        values: [100],
+        latestValue: 100,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.SMA],
+      });
+
+      expect(result.indicators.trend?.sma?.trend).toBe('bullish');
+    });
+
+    it('should interpret SMA price below as bearish trend', async () => {
+      // Set close price below SMA (80 < 100)
+      const mockCandles = createMockCandles(100, { closePrice: 80 });
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateSma.mockReturnValue({
+        period: 20,
+        values: [100],
+        latestValue: 100,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.SMA],
+      });
+
+      expect(result.indicators.trend?.sma?.trend).toBe('bearish');
+    });
+
+    it('should interpret EMA price above as bullish trend', async () => {
+      const mockCandles = createMockCandles(100, { closePrice: 150 });
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateEma.mockReturnValue({
+        period: 20,
+        values: [100],
+        latestValue: 100,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.EMA],
+      });
+
+      expect(result.indicators.trend?.ema?.trend).toBe('bullish');
+    });
+
+    it('should interpret EMA price below as bearish trend', async () => {
+      const mockCandles = createMockCandles(100, { closePrice: 80 });
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateEma.mockReturnValue({
+        period: 20,
+        values: [100],
+        latestValue: 100,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.EMA],
+      });
+
+      expect(result.indicators.trend?.ema?.trend).toBe('bearish');
+    });
+
+    it('should interpret Ichimoku bullish signal', async () => {
+      const mockCandles = createMockCandles(100, { closePrice: 110 });
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateIchimokuCloud.mockReturnValue({
+        conversionPeriod: 9,
+        basePeriod: 26,
+        spanPeriod: 52,
+        displacement: 26,
+        values: [
+          { conversion: 105, base: 103, spanA: 100, spanB: 95, chikou: 110 },
+        ],
+        latestValue: {
+          conversion: 105,
+          base: 103,
+          spanA: 100,
+          spanB: 95,
+          chikou: 110,
+        },
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.ICHIMOKU],
+      });
+
+      expect(result.indicators.trend?.ichimoku?.signal).toBe('bullish');
+    });
+
+    it('should interpret Ichimoku bearish signal', async () => {
+      const mockCandles = createMockCandles(100, { closePrice: 80 });
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateIchimokuCloud.mockReturnValue({
+        conversionPeriod: 9,
+        basePeriod: 26,
+        spanPeriod: 52,
+        displacement: 26,
+        values: [
+          { conversion: 95, base: 97, spanA: 100, spanB: 105, chikou: 80 },
+        ],
+        latestValue: {
+          conversion: 95,
+          base: 97,
+          spanA: 100,
+          spanB: 105,
+          chikou: 80,
+        },
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.ICHIMOKU],
+      });
+
+      expect(result.indicators.trend?.ichimoku?.signal).toBe('bearish');
+    });
+
+    it('should interpret PSAR below price as uptrend', async () => {
+      const mockCandles = createMockCandles(100, { closePrice: 110 });
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculatePsar.mockReturnValue({
+        step: 0.02,
+        max: 0.2,
+        values: [95],
+        latestValue: 95,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.PSAR],
+      });
+
+      expect(result.indicators.trend?.psar?.trend).toBe('up');
+    });
+
+    it('should interpret PSAR above price as downtrend', async () => {
+      const mockCandles = createMockCandles(100, { closePrice: 90 });
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculatePsar.mockReturnValue({
+        step: 0.02,
+        max: 0.2,
+        values: [110],
+        latestValue: 110,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.PSAR],
+      });
+
+      expect(result.indicators.trend?.psar?.trend).toBe('down');
+    });
+
+    it('should interpret Bollinger Bands price near lower band as oversold', async () => {
+      const mockCandles = createMockCandles(100, { closePrice: 92 });
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateBollingerBands.mockReturnValue({
+        period: 20,
+        stdDev: 2,
+        values: [
+          { upper: 110, middle: 100, lower: 90, pb: -0.1, bandwidth: 0.2 },
+        ],
+        latestValue: {
+          upper: 110,
+          middle: 100,
+          lower: 90,
+          pb: -0.1,
+          bandwidth: 0.2,
+        },
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.BOLLINGER_BANDS],
+      });
+
+      expect(result.indicators.volatility?.bollingerBands?.signal).toBe(
+        'oversold',
+      );
+    });
+
+    it('should interpret Bollinger Bands price near upper band as overbought', async () => {
+      const mockCandles = createMockCandles(100, { closePrice: 108 });
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateBollingerBands.mockReturnValue({
+        period: 20,
+        stdDev: 2,
+        values: [
+          { upper: 110, middle: 100, lower: 90, pb: 1.2, bandwidth: 0.2 },
+        ],
+        latestValue: {
+          upper: 110,
+          middle: 100,
+          lower: 90,
+          pb: 1.2,
+          bandwidth: 0.2,
+        },
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.BOLLINGER_BANDS],
+      });
+
+      expect(result.indicators.volatility?.bollingerBands?.signal).toBe(
+        'overbought',
+      );
+    });
+
+    it('should interpret OBV rising trend', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateObv.mockReturnValue({
+        values: [1000, 1200, 1500, 1800, 2200],
+        latestValue: 2200,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.OBV],
+      });
+
+      expect(result.indicators.volume?.obv?.trend).toBe('rising');
+    });
+
+    it('should interpret OBV falling trend', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateObv.mockReturnValue({
+        values: [2200, 1800, 1500, 1200, 1000],
+        latestValue: 1000,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.OBV],
+      });
+
+      expect(result.indicators.volume?.obv?.trend).toBe('falling');
+    });
+
+    it('should interpret MFI oversold (<20) as bullish', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateMfi.mockReturnValue({
+        period: 14,
+        values: [15],
+        latestValue: 15,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.MFI],
+      });
+
+      expect(result.indicators.volume?.mfi?.signal).toBe('oversold');
+    });
+
+    it('should interpret MFI overbought (>80) as bearish', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateMfi.mockReturnValue({
+        period: 14,
+        values: [85],
+        latestValue: 85,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.MFI],
+      });
+
+      expect(result.indicators.volume?.mfi?.signal).toBe('overbought');
+    });
+
+    it('should interpret VWAP price above as bullish position', async () => {
+      const mockCandles = createMockCandles(100, { closePrice: 110 });
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateVwap.mockReturnValue({
+        values: [100],
+        latestValue: 100,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.VWAP],
+      });
+
+      expect(result.indicators.volume?.vwap?.position).toBe('above');
+    });
+
+    it('should interpret VWAP price below as bearish position', async () => {
+      const mockCandles = createMockCandles(100, { closePrice: 90 });
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateVwap.mockReturnValue({
+        values: [100],
+        latestValue: 100,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.VWAP],
+      });
+
+      expect(result.indicators.volume?.vwap?.position).toBe('below');
+    });
+
+    it('should interpret candlestick patterns bullish bias', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.detectCandlestickPatterns.mockReturnValue({
+        bullish: true,
+        bearish: false,
+        patterns: [],
+        detectedPatterns: ['Hammer', 'Bullish Engulfing'],
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.CANDLESTICK_PATTERNS],
+      });
+
+      expect(result.indicators.patterns?.candlestickPatterns?.bias).toBe(
+        'bullish',
+      );
+    });
+
+    it('should interpret candlestick patterns bearish bias', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.detectCandlestickPatterns.mockReturnValue({
+        bullish: false,
+        bearish: true,
+        patterns: [],
+        detectedPatterns: ['Shooting Star', 'Bearish Engulfing'],
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.CANDLESTICK_PATTERNS],
+      });
+
+      expect(result.indicators.patterns?.candlestickPatterns?.bias).toBe(
+        'bearish',
+      );
+    });
+
+    it('should interpret RSI bullish divergence', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.detectRsiDivergence.mockReturnValue({
+        rsiPeriod: 14,
+        lookbackPeriod: 14,
+        rsiValues: [55],
+        divergences: [
+          {
+            type: 'bullish',
+            startIndex: 0,
+            endIndex: 5,
+            priceStart: 100,
+            priceEnd: 95,
+            rsiStart: 30,
+            rsiEnd: 40,
+            strength: 'strong',
+          },
+        ],
+        latestDivergence: {
+          type: 'bullish',
+          startIndex: 0,
+          endIndex: 5,
+          priceStart: 100,
+          priceEnd: 95,
+          rsiStart: 30,
+          rsiEnd: 40,
+          strength: 'strong',
+        },
+        hasBullishDivergence: true,
+        hasBearishDivergence: false,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.RSI_DIVERGENCE],
+      });
+
+      expect(result.indicators.patterns?.rsiDivergence?.type).toBe('bullish');
+    });
+
+    it('should interpret RSI bearish divergence', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.detectRsiDivergence.mockReturnValue({
+        rsiPeriod: 14,
+        lookbackPeriod: 14,
+        rsiValues: [55],
+        divergences: [
+          {
+            type: 'bearish',
+            startIndex: 0,
+            endIndex: 5,
+            priceStart: 95,
+            priceEnd: 100,
+            rsiStart: 70,
+            rsiEnd: 60,
+            strength: 'strong',
+          },
+        ],
+        latestDivergence: {
+          type: 'bearish',
+          startIndex: 0,
+          endIndex: 5,
+          priceStart: 95,
+          priceEnd: 100,
+          rsiStart: 70,
+          rsiEnd: 60,
+          strength: 'strong',
+        },
+        hasBullishDivergence: false,
+        hasBearishDivergence: true,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.RSI_DIVERGENCE],
+      });
+
+      expect(result.indicators.patterns?.rsiDivergence?.type).toBe('bearish');
+    });
+
+    it('should interpret chart patterns bullish direction', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.detectChartPatterns.mockReturnValue({
+        lookbackPeriod: 50,
+        patterns: [
+          {
+            type: 'double_bottom',
+            startIndex: 0,
+            endIndex: 50,
+            confidence: 'high',
+            direction: 'bullish',
+            priceTarget: 120,
+            neckline: 105,
+          },
+        ],
+        bullishPatterns: [
+          {
+            type: 'double_bottom',
+            startIndex: 0,
+            endIndex: 50,
+            confidence: 'high',
+            direction: 'bullish',
+            priceTarget: 120,
+            neckline: 105,
+          },
+        ],
+        bearishPatterns: [],
+        latestPattern: {
+          type: 'double_bottom',
+          startIndex: 0,
+          endIndex: 50,
+          confidence: 'high',
+          direction: 'bullish',
+          priceTarget: 120,
+          neckline: 105,
+        },
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.CHART_PATTERNS],
+      });
+
+      expect(result.indicators.patterns?.chartPatterns?.direction).toBe(
+        'bullish',
+      );
+    });
+
+    it('should interpret chart patterns bearish direction', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.detectChartPatterns.mockReturnValue({
+        lookbackPeriod: 50,
+        patterns: [
+          {
+            type: 'head_and_shoulders',
+            startIndex: 0,
+            endIndex: 50,
+            confidence: 'high',
+            direction: 'bearish',
+            priceTarget: 80,
+            neckline: 95,
+          },
+        ],
+        bullishPatterns: [],
+        bearishPatterns: [
+          {
+            type: 'head_and_shoulders',
+            startIndex: 0,
+            endIndex: 50,
+            confidence: 'high',
+            direction: 'bearish',
+            priceTarget: 80,
+            neckline: 95,
+          },
+        ],
+        latestPattern: {
+          type: 'head_and_shoulders',
+          startIndex: 0,
+          endIndex: 50,
+          confidence: 'high',
+          direction: 'bearish',
+          priceTarget: 80,
+          neckline: 95,
+        },
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.CHART_PATTERNS],
+      });
+
+      expect(result.indicators.patterns?.chartPatterns?.direction).toBe(
+        'bearish',
+      );
+    });
+
+    it('should interpret swing points downtrend', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.detectSwingPoints.mockReturnValue({
+        swingHighs: [{ index: 20, price: 110, type: 'high' as const }],
+        swingLows: [{ index: 80, price: 95, type: 'low' as const }],
+        latestSwingHigh: { index: 20, price: 110, type: 'high' as const },
+        latestSwingLow: { index: 80, price: 95, type: 'low' as const },
+        trend: 'downtrend' as const,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.SWING_POINTS],
+      });
+
+      expect(result.indicators.patterns?.swingPoints?.trend).toBe('downtrend');
+    });
+
+    it('should interpret swing points sideways trend', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.detectSwingPoints.mockReturnValue({
+        swingHighs: [{ index: 50, price: 110, type: 'high' as const }],
+        swingLows: [{ index: 50, price: 95, type: 'low' as const }],
+        latestSwingHigh: { index: 50, price: 110, type: 'high' as const },
+        latestSwingLow: { index: 50, price: 95, type: 'low' as const },
+        trend: 'sideways' as const,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.SWING_POINTS],
+      });
+
+      expect(result.indicators.patterns?.swingPoints?.trend).toBe('sideways');
+    });
+
+    it('should handle pivot points woodie type', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed
+        .mockResolvedValueOnce({ candles: mockCandles })
+        .mockResolvedValueOnce({
+          candles: [
+            { open: '90', high: '100', low: '85', close: '95', volume: '800' }, // Older
+            {
+              open: '100',
+              high: '110',
+              low: '95',
+              close: '105',
+              volume: '1000',
+            }, // Previous day
+          ],
+        });
+
+      mockIndicatorsService.calculatePivotPoints.mockReturnValue({
+        type: 'woodie',
+        pivotPoint: 100,
+        resistance1: 105,
+        resistance2: 110,
+        support1: 95,
+        support2: 90,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.PIVOT_POINTS],
+      });
+
+      expect(result.indicators.supportResistance?.pivotPoints?.pivot).toBe(100);
+    });
+
+    it('should handle pivot points demark type', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed
+        .mockResolvedValueOnce({ candles: mockCandles })
+        .mockResolvedValueOnce({
+          candles: [
+            { open: '90', high: '100', low: '85', close: '95', volume: '800' }, // Older
+            {
+              open: '100',
+              high: '110',
+              low: '95',
+              close: '105',
+              volume: '1000',
+            }, // Previous day
+          ],
+        });
+
+      mockIndicatorsService.calculatePivotPoints.mockReturnValue({
+        type: 'demark',
+        pivotPoint: 100,
+        resistance1: 105,
+        support1: 95,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.PIVOT_POINTS],
+      });
+
+      expect(result.indicators.supportResistance?.pivotPoints?.pivot).toBe(100);
+    });
+
+    it('should handle pivot points camarilla type', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed
+        .mockResolvedValueOnce({ candles: mockCandles })
+        .mockResolvedValueOnce({
+          candles: [
+            { open: '90', high: '100', low: '85', close: '95', volume: '800' }, // Older
+            {
+              open: '100',
+              high: '110',
+              low: '95',
+              close: '105',
+              volume: '1000',
+            }, // Previous day
+          ],
+        });
+
+      mockIndicatorsService.calculatePivotPoints.mockReturnValue({
+        type: 'camarilla',
+        pivotPoint: 100,
+        resistance1: 102,
+        resistance2: 104,
+        resistance3: 106,
+        resistance4: 108,
+        support1: 98,
+        support2: 96,
+        support3: 94,
+        support4: 92,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.PIVOT_POINTS],
+      });
+
+      expect(result.indicators.supportResistance?.pivotPoints?.pivot).toBe(100);
+    });
+
+    it('should interpret ROC neutral (value = 0)', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateRoc.mockReturnValue({
+        period: 12,
+        values: [0],
+        latestValue: 0, // Exactly zero - neutral
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.ROC],
+      });
+
+      expect(result.indicators.momentum?.roc?.signal).toBe('neutral');
+    });
+
+    it('should interpret ATR normal volatility (1.5% to 3%)', async () => {
+      const mockCandles = createMockCandles(100, { closePrice: 100 }); // Current price = 100
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      // ATR of 2 with price 100 = 2% volatility (normal)
+      mockIndicatorsService.calculateAtr.mockReturnValue({
+        period: 14,
+        values: [2],
+        latestValue: 2,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.ATR],
+      });
+
+      expect(result.indicators.volatility?.atr?.volatility).toBe('normal');
+    });
+
+    it('should interpret ATR low volatility (<1.5%)', async () => {
+      const mockCandles = createMockCandles(100, { closePrice: 100 }); // Current price = 100
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      // ATR of 1 with price 100 = 1% volatility (low)
+      mockIndicatorsService.calculateAtr.mockReturnValue({
+        period: 14,
+        values: [1],
+        latestValue: 1,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.ATR],
+      });
+
+      expect(result.indicators.volatility?.atr?.volatility).toBe('low');
+    });
+
+    it('should calculate aggregated signal with all indicator types', async () => {
+      const mockCandles = createMockCandles(100, { closePrice: 150 });
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      // Mock all indicators with bullish signals
+      mockIndicatorsService.calculateRsi.mockReturnValue({
+        period: 14,
+        values: [25],
+        latestValue: 25, // Oversold - bullish
+      });
+      mockIndicatorsService.calculateMacd.mockReturnValue({
+        fastPeriod: 12,
+        slowPeriod: 26,
+        signalPeriod: 9,
+        values: [
+          { MACD: 0.5, signal: 1.0, histogram: -0.5 },
+          { MACD: 1.5, signal: 1.0, histogram: 0.5 },
+        ],
+        latestValue: { MACD: 1.5, signal: 1.0, histogram: 0.5 },
+      });
+      mockIndicatorsService.calculateStochastic.mockReturnValue({
+        kPeriod: 14,
+        dPeriod: 3,
+        values: [{ k: 15, d: 18 }],
+        latestValue: { k: 15, d: 18 }, // Oversold - bullish
+      });
+      mockIndicatorsService.calculateAdx.mockReturnValue({
+        period: 14,
+        values: [{ adx: 30, pdi: 35, mdi: 20 }],
+        latestValue: { adx: 30, pdi: 35, mdi: 20 }, // PDI > MDI - bullish
+      });
+      mockIndicatorsService.calculateCci.mockReturnValue({
+        period: 20,
+        values: [-150],
+        latestValue: -150, // Oversold - bullish
+      });
+      mockIndicatorsService.calculateWilliamsR.mockReturnValue({
+        period: 14,
+        values: [-90],
+        latestValue: -90, // Oversold - bullish
+      });
+      mockIndicatorsService.calculateRoc.mockReturnValue({
+        period: 12,
+        values: [5.5],
+        latestValue: 5.5, // Positive - bullish
+      });
+      mockIndicatorsService.calculateSma.mockReturnValue({
+        period: 20,
+        values: [100],
+        latestValue: 100, // Price above SMA - bullish
+      });
+      mockIndicatorsService.calculateEma.mockReturnValue({
+        period: 20,
+        values: [100],
+        latestValue: 100, // Price above EMA - bullish
+      });
+      mockIndicatorsService.calculateIchimokuCloud.mockReturnValue({
+        conversionPeriod: 9,
+        basePeriod: 26,
+        spanPeriod: 52,
+        displacement: 26,
+        values: [
+          { conversion: 105, base: 103, spanA: 100, spanB: 95, chikou: 110 },
+        ],
+        latestValue: {
+          conversion: 105,
+          base: 103,
+          spanA: 100,
+          spanB: 95,
+          chikou: 110,
+        },
+      });
+      mockIndicatorsService.calculatePsar.mockReturnValue({
+        step: 0.02,
+        max: 0.2,
+        values: [95],
+        latestValue: 95, // Below price - uptrend
+      });
+      mockIndicatorsService.calculateBollingerBands.mockReturnValue({
+        period: 20,
+        stdDev: 2,
+        values: [
+          { upper: 160, middle: 150, lower: 140, pb: 0.5, bandwidth: 0.13 },
+        ],
+        latestValue: {
+          upper: 160,
+          middle: 150,
+          lower: 140,
+          pb: 0.5,
+          bandwidth: 0.13,
+        },
+      });
+      mockIndicatorsService.calculateAtr.mockReturnValue({
+        period: 14,
+        values: [5],
+        latestValue: 5,
+      });
+      mockIndicatorsService.calculateKeltnerChannels.mockReturnValue({
+        maPeriod: 20,
+        atrPeriod: 10,
+        multiplier: 2,
+        useSMA: false,
+        values: [{ middle: 100, upper: 110, lower: 90 }],
+        latestValue: { middle: 100, upper: 110, lower: 90 },
+      });
+      mockIndicatorsService.calculateObv.mockReturnValue({
+        values: [1000, 1200, 1500, 1800, 2200],
+        latestValue: 2200, // Rising - bullish
+      });
+      mockIndicatorsService.calculateMfi.mockReturnValue({
+        period: 14,
+        values: [15],
+        latestValue: 15, // Oversold - bullish
+      });
+      mockIndicatorsService.calculateVwap.mockReturnValue({
+        values: [100],
+        latestValue: 100, // Price above - bullish
+      });
+      mockIndicatorsService.calculateVolumeProfile.mockReturnValue({
+        noOfBars: 12,
+        zones: [
+          {
+            rangeStart: 95,
+            rangeEnd: 105,
+            bullishVolume: 500,
+            bearishVolume: 400,
+            totalVolume: 900,
+          },
+        ],
+        pointOfControl: {
+          rangeStart: 100,
+          rangeEnd: 105,
+          bullishVolume: 500,
+          bearishVolume: 400,
+          totalVolume: 900,
+        },
+        valueAreaHigh: 110,
+        valueAreaLow: 90,
+      });
+      mockIndicatorsService.detectCandlestickPatterns.mockReturnValue({
+        bullish: true,
+        bearish: false,
+        patterns: [],
+        detectedPatterns: ['Hammer'],
+      });
+      mockIndicatorsService.detectRsiDivergence.mockReturnValue({
+        rsiPeriod: 14,
+        lookbackPeriod: 14,
+        rsiValues: [55],
+        divergences: [
+          {
+            type: 'bullish',
+            startIndex: 0,
+            endIndex: 5,
+            priceStart: 100,
+            priceEnd: 95,
+            rsiStart: 30,
+            rsiEnd: 40,
+            strength: 'strong',
+          },
+        ],
+        latestDivergence: {
+          type: 'bullish',
+          startIndex: 0,
+          endIndex: 5,
+          priceStart: 100,
+          priceEnd: 95,
+          rsiStart: 30,
+          rsiEnd: 40,
+          strength: 'strong',
+        },
+        hasBullishDivergence: true,
+        hasBearishDivergence: false,
+      });
+      mockIndicatorsService.detectChartPatterns.mockReturnValue({
+        lookbackPeriod: 50,
+        patterns: [
+          {
+            type: 'double_bottom',
+            startIndex: 0,
+            endIndex: 50,
+            confidence: 'high',
+            direction: 'bullish',
+            priceTarget: 120,
+            neckline: 105,
+          },
+        ],
+        bullishPatterns: [
+          {
+            type: 'double_bottom',
+            startIndex: 0,
+            endIndex: 50,
+            confidence: 'high',
+            direction: 'bullish',
+            priceTarget: 120,
+            neckline: 105,
+          },
+        ],
+        bearishPatterns: [],
+        latestPattern: {
+          type: 'double_bottom',
+          startIndex: 0,
+          endIndex: 50,
+          confidence: 'high',
+          direction: 'bullish',
+          priceTarget: 120,
+          neckline: 105,
+        },
+      });
+      mockIndicatorsService.detectSwingPoints.mockReturnValue({
+        swingHighs: [{ index: 80, price: 150, type: 'high' as const }],
+        swingLows: [{ index: 20, price: 100, type: 'low' as const }],
+        latestSwingHigh: { index: 80, price: 150, type: 'high' as const },
+        latestSwingLow: { index: 20, price: 100, type: 'low' as const },
+        trend: 'uptrend' as const,
+      });
+      mockIndicatorsService.calculateFibonacciRetracement.mockReturnValue({
+        start: 100,
+        end: 150,
+        trend: 'uptrend',
+        levels: [
+          { level: 0, price: 100 },
+          { level: 50, price: 125 },
+          { level: 100, price: 150 },
+        ],
+      });
+      mockIndicatorsService.calculatePivotPoints.mockReturnValue({
+        type: 'standard',
+        pivotPoint: 120,
+        resistance1: 130,
+        resistance2: 140,
+        resistance3: 150,
+        support1: 110,
+        support2: 100,
+        support3: 90,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+      });
+
+      // Should have a strong bullish signal
+      expect(result.signal.score).toBeGreaterThan(50);
+      expect(['STRONG_BUY', 'BUY']).toContain(result.signal.direction);
+    });
+
+    it('should calculate aggregated signal with bearish indicators', async () => {
+      const mockCandles = createMockCandles(100, { closePrice: 80 });
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      // Mock all indicators with bearish signals
+      mockIndicatorsService.calculateRsi.mockReturnValue({
+        period: 14,
+        values: [75],
+        latestValue: 75, // Overbought - bearish
+      });
+      mockIndicatorsService.calculateMacd.mockReturnValue({
+        fastPeriod: 12,
+        slowPeriod: 26,
+        signalPeriod: 9,
+        values: [
+          { MACD: 1.5, signal: 1.0, histogram: 0.5 },
+          { MACD: 0.5, signal: 1.0, histogram: -0.5 },
+        ],
+        latestValue: { MACD: 0.5, signal: 1.0, histogram: -0.5 }, // Bearish crossover
+      });
+      mockIndicatorsService.calculateStochastic.mockReturnValue({
+        kPeriod: 14,
+        dPeriod: 3,
+        values: [{ k: 85, d: 82 }],
+        latestValue: { k: 85, d: 82 }, // Overbought - bearish
+      });
+      mockIndicatorsService.calculateAdx.mockReturnValue({
+        period: 14,
+        values: [{ adx: 30, pdi: 20, mdi: 35 }],
+        latestValue: { adx: 30, pdi: 20, mdi: 35 }, // MDI > PDI - bearish
+      });
+      mockIndicatorsService.calculateCci.mockReturnValue({
+        period: 20,
+        values: [150],
+        latestValue: 150, // Overbought - bearish
+      });
+      mockIndicatorsService.calculateWilliamsR.mockReturnValue({
+        period: 14,
+        values: [-10],
+        latestValue: -10, // Overbought - bearish
+      });
+      mockIndicatorsService.calculateRoc.mockReturnValue({
+        period: 12,
+        values: [-5.5],
+        latestValue: -5.5, // Negative - bearish
+      });
+      mockIndicatorsService.calculateSma.mockReturnValue({
+        period: 20,
+        values: [100],
+        latestValue: 100, // Price below SMA - bearish
+      });
+      mockIndicatorsService.calculateEma.mockReturnValue({
+        period: 20,
+        values: [100],
+        latestValue: 100, // Price below EMA - bearish
+      });
+      mockIndicatorsService.calculateIchimokuCloud.mockReturnValue({
+        conversionPeriod: 9,
+        basePeriod: 26,
+        spanPeriod: 52,
+        displacement: 26,
+        values: [
+          { conversion: 95, base: 97, spanA: 100, spanB: 105, chikou: 80 },
+        ],
+        latestValue: {
+          conversion: 95,
+          base: 97,
+          spanA: 100,
+          spanB: 105,
+          chikou: 80,
+        },
+      });
+      mockIndicatorsService.calculatePsar.mockReturnValue({
+        step: 0.02,
+        max: 0.2,
+        values: [110],
+        latestValue: 110, // Above price - downtrend
+      });
+      mockIndicatorsService.calculateBollingerBands.mockReturnValue({
+        period: 20,
+        stdDev: 2,
+        values: [
+          { upper: 85, middle: 75, lower: 65, pb: 0.5, bandwidth: 0.27 },
+        ],
+        latestValue: {
+          upper: 85,
+          middle: 75,
+          lower: 65,
+          pb: 0.5,
+          bandwidth: 0.27,
+        },
+      });
+      mockIndicatorsService.calculateAtr.mockReturnValue({
+        period: 14,
+        values: [5],
+        latestValue: 5,
+      });
+      mockIndicatorsService.calculateKeltnerChannels.mockReturnValue({
+        maPeriod: 20,
+        atrPeriod: 10,
+        multiplier: 2,
+        useSMA: false,
+        values: [{ middle: 100, upper: 110, lower: 90 }],
+        latestValue: { middle: 100, upper: 110, lower: 90 },
+      });
+      mockIndicatorsService.calculateObv.mockReturnValue({
+        values: [2200, 1800, 1500, 1200, 1000],
+        latestValue: 1000, // Falling - bearish
+      });
+      mockIndicatorsService.calculateMfi.mockReturnValue({
+        period: 14,
+        values: [85],
+        latestValue: 85, // Overbought - bearish
+      });
+      mockIndicatorsService.calculateVwap.mockReturnValue({
+        values: [100],
+        latestValue: 100, // Price below - bearish
+      });
+      mockIndicatorsService.calculateVolumeProfile.mockReturnValue({
+        noOfBars: 12,
+        zones: [
+          {
+            rangeStart: 95,
+            rangeEnd: 105,
+            bullishVolume: 400,
+            bearishVolume: 500,
+            totalVolume: 900,
+          },
+        ],
+        pointOfControl: {
+          rangeStart: 100,
+          rangeEnd: 105,
+          bullishVolume: 400,
+          bearishVolume: 500,
+          totalVolume: 900,
+        },
+        valueAreaHigh: 110,
+        valueAreaLow: 90,
+      });
+      mockIndicatorsService.detectCandlestickPatterns.mockReturnValue({
+        bullish: false,
+        bearish: true,
+        patterns: [],
+        detectedPatterns: ['Shooting Star'],
+      });
+      mockIndicatorsService.detectRsiDivergence.mockReturnValue({
+        rsiPeriod: 14,
+        lookbackPeriod: 14,
+        rsiValues: [55],
+        divergences: [
+          {
+            type: 'bearish',
+            startIndex: 0,
+            endIndex: 5,
+            priceStart: 95,
+            priceEnd: 100,
+            rsiStart: 70,
+            rsiEnd: 60,
+            strength: 'strong',
+          },
+        ],
+        latestDivergence: {
+          type: 'bearish',
+          startIndex: 0,
+          endIndex: 5,
+          priceStart: 95,
+          priceEnd: 100,
+          rsiStart: 70,
+          rsiEnd: 60,
+          strength: 'strong',
+        },
+        hasBullishDivergence: false,
+        hasBearishDivergence: true,
+      });
+      mockIndicatorsService.detectChartPatterns.mockReturnValue({
+        lookbackPeriod: 50,
+        patterns: [
+          {
+            type: 'head_and_shoulders',
+            startIndex: 0,
+            endIndex: 50,
+            confidence: 'high',
+            direction: 'bearish',
+            priceTarget: 80,
+            neckline: 95,
+          },
+        ],
+        bullishPatterns: [],
+        bearishPatterns: [
+          {
+            type: 'head_and_shoulders',
+            startIndex: 0,
+            endIndex: 50,
+            confidence: 'high',
+            direction: 'bearish',
+            priceTarget: 80,
+            neckline: 95,
+          },
+        ],
+        latestPattern: {
+          type: 'head_and_shoulders',
+          startIndex: 0,
+          endIndex: 50,
+          confidence: 'high',
+          direction: 'bearish',
+          priceTarget: 80,
+          neckline: 95,
+        },
+      });
+      mockIndicatorsService.detectSwingPoints.mockReturnValue({
+        swingHighs: [{ index: 20, price: 110, type: 'high' as const }],
+        swingLows: [{ index: 80, price: 95, type: 'low' as const }],
+        latestSwingHigh: { index: 20, price: 110, type: 'high' as const },
+        latestSwingLow: { index: 80, price: 95, type: 'low' as const },
+        trend: 'downtrend' as const,
+      });
+      mockIndicatorsService.calculateFibonacciRetracement.mockReturnValue({
+        start: 100,
+        end: 80,
+        trend: 'downtrend',
+        levels: [
+          { level: 0, price: 100 },
+          { level: 50, price: 90 },
+          { level: 100, price: 80 },
+        ],
+      });
+      mockIndicatorsService.calculatePivotPoints.mockReturnValue({
+        type: 'standard',
+        pivotPoint: 90,
+        resistance1: 100,
+        resistance2: 110,
+        resistance3: 120,
+        support1: 80,
+        support2: 70,
+        support3: 60,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+      });
+
+      // Should have a strong bearish signal
+      expect(result.signal.score).toBeLessThan(-50);
+      expect(['STRONG_SELL', 'SELL']).toContain(result.signal.direction);
+    });
+
+    it('should interpret MACD no crossover as none', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      // MACD remains above signal line (no crossover)
+      mockIndicatorsService.calculateMacd.mockReturnValue({
+        fastPeriod: 12,
+        slowPeriod: 26,
+        signalPeriod: 9,
+        values: [
+          { MACD: 1.5, signal: 1.0, histogram: 0.5 },
+          { MACD: 2.0, signal: 1.0, histogram: 1.0 },
+        ],
+        latestValue: { MACD: 2.0, signal: 1.0, histogram: 1.0 },
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.MACD],
+      });
+
+      expect(result.indicators.momentum?.macd?.crossover).toBe('none');
+    });
+
+    it('should interpret ADX moderate strength (20-25)', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateAdx.mockReturnValue({
+        period: 14,
+        values: [{ adx: 22, pdi: 30, mdi: 20 }],
+        latestValue: { adx: 22, pdi: 30, mdi: 20 },
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.ADX],
+      });
+
+      expect(result.indicators.momentum?.adx?.trendStrength).toBe('moderate');
+    });
+
+    it('should interpret ADX weak strength (<20)', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateAdx.mockReturnValue({
+        period: 14,
+        values: [{ adx: 15, pdi: 25, mdi: 20 }],
+        latestValue: { adx: 15, pdi: 25, mdi: 20 },
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.ADX],
+      });
+
+      expect(result.indicators.momentum?.adx?.trendStrength).toBe('weak');
+    });
+
+    it('should interpret Stochastic neutral (20 < k < 80)', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateStochastic.mockReturnValue({
+        kPeriod: 14,
+        dPeriod: 3,
+        values: [{ k: 50, d: 45 }],
+        latestValue: { k: 50, d: 45 },
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.STOCHASTIC],
+      });
+
+      expect(result.indicators.momentum?.stochastic?.signal).toBe('neutral');
+    });
+
+    it('should interpret CCI neutral (-100 < value < 100)', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateCci.mockReturnValue({
+        period: 20,
+        values: [50],
+        latestValue: 50,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.CCI],
+      });
+
+      expect(result.indicators.momentum?.cci?.signal).toBe('neutral');
+    });
+
+    it('should interpret Williams %R neutral (-80 < value < -20)', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateWilliamsR.mockReturnValue({
+        period: 14,
+        values: [-50],
+        latestValue: -50,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.WILLIAMS_R],
+      });
+
+      expect(result.indicators.momentum?.williamsR?.signal).toBe('neutral');
+    });
+
+    it('should interpret Ichimoku neutral signal', async () => {
+      const mockCandles = createMockCandles(100, { closePrice: 102 }); // Price in the cloud
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateIchimokuCloud.mockReturnValue({
+        conversionPeriod: 9,
+        basePeriod: 26,
+        spanPeriod: 52,
+        displacement: 26,
+        values: [
+          { conversion: 100, base: 100, spanA: 100, spanB: 105, chikou: 102 },
+        ],
+        latestValue: {
+          conversion: 100,
+          base: 100,
+          spanA: 100,
+          spanB: 105,
+          chikou: 102,
+        },
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.ICHIMOKU],
+      });
+
+      expect(result.indicators.trend?.ichimoku?.signal).toBe('neutral');
+    });
+
+    it('should return BUY direction for score between 20 and 50', async () => {
+      const mockCandles = createMockCandles(100, { closePrice: 105 });
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      // Set up 5 indicators: 2 bullish, 3 neutral = 40% bullish = score 40
+      mockIndicatorsService.calculateRsi.mockReturnValue({
+        period: 14,
+        values: [50],
+        latestValue: 50, // Neutral
+      });
+      mockIndicatorsService.calculateStochastic.mockReturnValue({
+        kPeriod: 14,
+        dPeriod: 3,
+        values: [{ k: 50, d: 50 }],
+        latestValue: { k: 50, d: 50 }, // Neutral
+      });
+      mockIndicatorsService.calculateCci.mockReturnValue({
+        period: 20,
+        values: [0],
+        latestValue: 0, // Neutral
+      });
+      mockIndicatorsService.calculateSma.mockReturnValue({
+        period: 20,
+        values: [100],
+        latestValue: 100, // Price above - bullish
+      });
+      mockIndicatorsService.calculateEma.mockReturnValue({
+        period: 20,
+        values: [100],
+        latestValue: 100, // Price above - bullish
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [
+          IndicatorType.RSI,
+          IndicatorType.STOCHASTIC,
+          IndicatorType.CCI,
+          IndicatorType.SMA,
+          IndicatorType.EMA,
+        ],
+      });
+
+      // Should be a moderate bullish signal (BUY)
+      expect(result.signal.direction).toBe('BUY');
+    });
+
+    it('should return SELL direction for score between -50 and -20', async () => {
+      const mockCandles = createMockCandles(100, { closePrice: 95 });
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      // Set up 5 indicators: 2 bearish, 3 neutral = 40% bearish = score -40
+      mockIndicatorsService.calculateRsi.mockReturnValue({
+        period: 14,
+        values: [50],
+        latestValue: 50, // Neutral
+      });
+      mockIndicatorsService.calculateStochastic.mockReturnValue({
+        kPeriod: 14,
+        dPeriod: 3,
+        values: [{ k: 50, d: 50 }],
+        latestValue: { k: 50, d: 50 }, // Neutral
+      });
+      mockIndicatorsService.calculateCci.mockReturnValue({
+        period: 20,
+        values: [0],
+        latestValue: 0, // Neutral
+      });
+      mockIndicatorsService.calculateSma.mockReturnValue({
+        period: 20,
+        values: [100],
+        latestValue: 100, // Price below - bearish
+      });
+      mockIndicatorsService.calculateEma.mockReturnValue({
+        period: 20,
+        values: [100],
+        latestValue: 100, // Price below - bearish
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [
+          IndicatorType.RSI,
+          IndicatorType.STOCHASTIC,
+          IndicatorType.CCI,
+          IndicatorType.SMA,
+          IndicatorType.EMA,
+        ],
+      });
+
+      // Should be a moderate bearish signal (SELL)
+      expect(result.signal.direction).toBe('SELL');
+    });
+
+    it('should return NEUTRAL direction when signals are balanced', async () => {
+      const mockCandles = createMockCandles(100, { closePrice: 100 }); // Price at SMA/EMA level
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      // Set up indicators with balanced signals
+      mockIndicatorsService.calculateRsi.mockReturnValue({
+        period: 14,
+        values: [50],
+        latestValue: 50, // Neutral
+      });
+      mockIndicatorsService.calculateStochastic.mockReturnValue({
+        kPeriod: 14,
+        dPeriod: 3,
+        values: [{ k: 50, d: 50 }],
+        latestValue: { k: 50, d: 50 }, // Neutral
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.RSI, IndicatorType.STOCHASTIC],
+      });
+
+      // Should be neutral with only neutral signals
+      expect(result.signal.direction).toBe('NEUTRAL');
+    });
+
+    it('should return LOW confidence with less than 5 signals', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      // Use only 1 indicator (less than 5 signals)
+      mockIndicatorsService.calculateRsi.mockReturnValue({
+        period: 14,
+        values: [25],
+        latestValue: 25,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.RSI],
+      });
+
+      expect(result.signal.confidence).toBe('LOW');
+    });
+
+    it('should return LOW confidence with low agreement rate', async () => {
+      const mockCandles = createMockCandles(100, { closePrice: 100 });
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      // Set up 6 indicators with mixed signals (low agreement)
+      mockIndicatorsService.calculateRsi.mockReturnValue({
+        period: 14,
+        values: [75],
+        latestValue: 75, // Overbought - bearish
+      });
+      mockIndicatorsService.calculateMacd.mockReturnValue({
+        fastPeriod: 12,
+        slowPeriod: 26,
+        signalPeriod: 9,
+        values: [
+          { MACD: 0.5, signal: 1.0, histogram: -0.5 },
+          { MACD: 1.5, signal: 1.0, histogram: 0.5 },
+        ],
+        latestValue: { MACD: 1.5, signal: 1.0, histogram: 0.5 }, // Bullish
+      });
+      mockIndicatorsService.calculateStochastic.mockReturnValue({
+        kPeriod: 14,
+        dPeriod: 3,
+        values: [{ k: 85, d: 82 }],
+        latestValue: { k: 85, d: 82 }, // Overbought - bearish
+      });
+      mockIndicatorsService.calculateAdx.mockReturnValue({
+        period: 14,
+        values: [{ adx: 30, pdi: 25, mdi: 25 }],
+        latestValue: { adx: 30, pdi: 25, mdi: 25 }, // Neutral (pdi == mdi)
+      });
+      mockIndicatorsService.calculateCci.mockReturnValue({
+        period: 20,
+        values: [50],
+        latestValue: 50, // Neutral
+      });
+      mockIndicatorsService.calculateWilliamsR.mockReturnValue({
+        period: 14,
+        values: [-10],
+        latestValue: -10, // Overbought - bearish
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [
+          IndicatorType.RSI,
+          IndicatorType.MACD,
+          IndicatorType.STOCHASTIC,
+          IndicatorType.ADX,
+          IndicatorType.CCI,
+          IndicatorType.WILLIAMS_R,
+        ],
+      });
+
+      // With 6 signals and mixed signals, should have LOW confidence
+      expect(['LOW', 'MEDIUM']).toContain(result.signal.confidence);
+    });
+  });
+
+  describe('edge cases and null handling', () => {
+    it('should handle API candles with null/undefined fields', async () => {
+      // API might return candles with missing fields
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: [
+          {
+            open: undefined,
+            high: '102',
+            low: '98',
+            close: '101',
+            volume: '1000',
+          },
+          {
+            open: '101',
+            high: undefined,
+            low: '98',
+            close: '102',
+            volume: '1000',
+          },
+          {
+            open: '102',
+            high: '105',
+            low: undefined,
+            close: '103',
+            volume: '1000',
+          },
+          {
+            open: '103',
+            high: '106',
+            low: '100',
+            close: undefined,
+            volume: '1000',
+          },
+          {
+            open: '104',
+            high: '107',
+            low: '101',
+            close: '105',
+            volume: undefined,
+          },
+        ] as unknown as {
+          open: string;
+          high: string;
+          low: string;
+          close: string;
+          volume: string;
+        }[],
+      });
+
+      mockIndicatorsService.calculateRsi.mockReturnValue({
+        period: 14,
+        values: [50],
+        latestValue: 50,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.RSI],
+      });
+
+      // Should handle nullish values with defaults
+      expect(result).toBeDefined();
+      expect(result.indicators.momentum?.rsi).toBeDefined();
+    });
+
+    it('should handle empty candles array from API', async () => {
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: undefined,
+      } as unknown as {
+        candles: {
+          open: string;
+          high: string;
+          low: string;
+          close: string;
+          volume: string;
+        }[];
+      });
+
+      mockIndicatorsService.calculateRsi.mockReturnValue({
+        period: 14,
+        values: [],
+        latestValue: null,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.RSI],
+      });
+
+      expect(result).toBeDefined();
+    });
+
+    it('should handle zero open price in price summary calculation', async () => {
+      // Create candles with first candle having open=0 (edge case for division by zero)
+      // Service uses candles[length-1] as oldest and candles[0] as latest
+      const candlesWithZeroOpen = [
+        { open: '101', high: '105', low: '99', close: '104', volume: '1100' }, // Latest (index 0)
+        { open: '0', high: '102', low: '98', close: '101', volume: '1000' }, // Oldest with open=0
+      ];
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: candlesWithZeroOpen,
+      });
+
+      mockIndicatorsService.calculateRsi.mockReturnValue({
+        period: 14,
+        values: [50],
+        latestValue: 50,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.RSI],
+      });
+
+      // Should be 0 when open is 0 (avoiding division by zero)
+      expect(result.price.change24h).toBe(0);
+    });
+
+    it('should handle MACD with null signal and histogram', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateMacd.mockReturnValue({
+        fastPeriod: 12,
+        slowPeriod: 26,
+        signalPeriod: 9,
+        values: [{ MACD: 1.5, signal: undefined, histogram: undefined }],
+        latestValue: { MACD: 1.5, signal: undefined, histogram: undefined },
+      } as unknown as ReturnType<typeof mockIndicatorsService.calculateMacd>);
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.MACD],
+      });
+
+      expect(result.indicators.momentum?.macd?.signal).toBe(0);
+      expect(result.indicators.momentum?.macd?.histogram).toBe(0);
+    });
+
+    it('should handle daily candles for pivot points (triggers fetchDailyCandles null handling)', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed
+        .mockResolvedValueOnce({ candles: mockCandles })
+        .mockResolvedValueOnce({
+          // Need at least 2 daily candles (service uses index 1 for previous day)
+          candles: [
+            {
+              open: '105',
+              high: '115',
+              low: '100',
+              close: '110',
+              volume: '1100',
+            }, // Current incomplete day
+            {
+              open: '100',
+              high: '110',
+              low: '95',
+              close: '105',
+              volume: '1000',
+            }, // Previous day
+          ],
+        });
+
+      mockIndicatorsService.calculatePivotPoints.mockReturnValue({
+        type: 'standard',
+        pivotPoint: 100,
+        resistance1: 105,
+        resistance2: 110,
+        resistance3: 115,
+        support1: 95,
+        support2: 90,
+        support3: 85,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.PIVOT_POINTS],
+      });
+
+      expect(result.indicators.supportResistance?.pivotPoints).toBeDefined();
+    });
+
+    it('should handle Stochastic with valid values', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateStochastic.mockReturnValue({
+        kPeriod: 14,
+        dPeriod: 3,
+        values: [{ k: 75, d: 70 }],
+        latestValue: { k: 75, d: 70 },
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.STOCHASTIC],
+      });
+
+      expect(result.indicators.momentum?.stochastic?.d).toBe(70);
+    });
+
+    it('should handle ATR when current price is zero (edge case)', async () => {
+      // Create candles where the latest close price is 0
+      const candlesWithZeroPrice = [
+        { open: '0', high: '0', low: '0', close: '0', volume: '1000' },
+        { open: '100', high: '105', low: '95', close: '101', volume: '1000' },
+      ];
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: candlesWithZeroPrice,
+      });
+
+      mockIndicatorsService.calculateAtr.mockReturnValue({
+        period: 14,
+        values: [5],
+        latestValue: 5,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.ATR],
+      });
+
+      // ATR should handle zero price without division error
+      expect(result.indicators.volatility?.atr).toBeDefined();
+    });
+
+    it('should not include indicators when latestValue is null', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      // All indicators return null latestValue
+      mockIndicatorsService.calculateStochastic.mockReturnValue({
+        kPeriod: 14,
+        dPeriod: 3,
+        values: [],
+        latestValue: null,
+      });
+
+      mockIndicatorsService.calculateBollingerBands.mockReturnValue({
+        period: 20,
+        stdDev: 2,
+        values: [],
+        latestValue: null,
+      });
+
+      mockIndicatorsService.calculateKeltnerChannels.mockReturnValue({
+        maPeriod: 20,
+        atrPeriod: 10,
+        multiplier: 2,
+        useSMA: false,
+        values: [],
+        latestValue: null,
+      });
+
+      mockIndicatorsService.calculateIchimokuCloud.mockReturnValue({
+        conversionPeriod: 9,
+        basePeriod: 26,
+        spanPeriod: 52,
+        displacement: 26,
+        values: [],
+        latestValue: null,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [
+          IndicatorType.STOCHASTIC,
+          IndicatorType.BOLLINGER_BANDS,
+          IndicatorType.KELTNER,
+          IndicatorType.ICHIMOKU,
+        ],
+      });
+
+      // Indicators with null latestValue should not be included
+      expect(result.indicators.momentum?.stochastic).toBeUndefined();
+      expect(result.indicators.volatility?.bollingerBands).toBeUndefined();
+      expect(result.indicators.volatility?.keltner).toBeUndefined();
+      expect(result.indicators.trend?.ichimoku).toBeUndefined();
+    });
+
+    it('should handle volume profile with valid values', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateVolumeProfile.mockReturnValue({
+        noOfBars: 10,
+        zones: [],
+        pointOfControl: {
+          rangeStart: 100,
+          rangeEnd: 105,
+          bullishVolume: 500,
+          bearishVolume: 400,
+          totalVolume: 1000,
+        },
+        valueAreaHigh: 110,
+        valueAreaLow: 90,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.VOLUME_PROFILE],
+      });
+
+      expect(result.indicators.volume?.volumeProfile).toBeDefined();
+    });
+
+    it('should handle OBV with null latestValue', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateObv.mockReturnValue({
+        values: [],
+        latestValue: null,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.OBV],
+      });
+
+      // OBV should not be included when latestValue is null
+      expect(result.indicators.volume?.obv).toBeUndefined();
+    });
+
+    it('should interpret OBV flat trend when values are equal', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      // OBV with equal latest and previous values
+      mockIndicatorsService.calculateObv.mockReturnValue({
+        values: [1000, 1000], // Equal values = flat trend
+        latestValue: 1000,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.OBV],
+      });
+
+      expect(result.indicators.volume?.obv?.trend).toBe('flat');
+    });
+
+    it('should handle volume profile with null valueAreaHigh/Low', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.calculateVolumeProfile.mockReturnValue({
+        numRows: 10,
+        rowSize: 1,
+        zones: [],
+        pointOfControl: {
+          rangeStart: 100,
+          rangeEnd: 105,
+          bullishVolume: 500,
+          bearishVolume: 400,
+          totalVolume: 1000,
+        },
+        valueAreaHigh: undefined, // Null trigger
+        valueAreaLow: undefined, // Null trigger
+      } as unknown as ReturnType<
+        typeof mockIndicatorsService.calculateVolumeProfile
+      >);
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.VOLUME_PROFILE],
+      });
+
+      expect(result.indicators.volume?.volumeProfile?.valueAreaHigh).toBe(0);
+      expect(result.indicators.volume?.volumeProfile?.valueAreaLow).toBe(0);
+    });
+
+    it('should handle fetchDailyCandles with null API fields', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed
+        .mockResolvedValueOnce({ candles: mockCandles })
+        .mockResolvedValueOnce({
+          candles: [
+            {
+              open: undefined,
+              high: undefined,
+              low: undefined,
+              close: undefined,
+              volume: undefined,
+            },
+            {
+              open: undefined,
+              high: undefined,
+              low: undefined,
+              close: undefined,
+              volume: undefined,
+            },
+          ],
+        } as unknown as {
+          candles: {
+            open: string;
+            high: string;
+            low: string;
+            close: string;
+            volume: string;
+          }[];
+        });
+
+      mockIndicatorsService.calculatePivotPoints.mockReturnValue({
+        type: 'standard',
+        pivotPoint: 0,
+        resistance1: 0,
+        resistance2: 0,
+        resistance3: 0,
+        support1: 0,
+        support2: 0,
+        support3: 0,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.PIVOT_POINTS],
+      });
+
+      // Should use '0' defaults for null fields
+      expect(result.indicators.supportResistance?.pivotPoints).toBeDefined();
+    });
+
+    it('should handle swing points with null latest prices', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      // Swing points with null latest values
+      mockIndicatorsService.detectSwingPoints.mockReturnValue({
+        swingHighs: [],
+        swingLows: [],
+        latestSwingHigh: null,
+        latestSwingLow: null,
+        trend: 'sideways' as const,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.SWING_POINTS],
+      });
+
+      expect(
+        result.indicators.patterns?.swingPoints?.latestSwingHigh,
+      ).toBeNull();
+      expect(
+        result.indicators.patterns?.swingPoints?.latestSwingLow,
+      ).toBeNull();
+    });
+
+    it('should handle RSI divergence with null latest divergence', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.detectRsiDivergence.mockReturnValue({
+        rsiPeriod: 14,
+        lookbackPeriod: 14,
+        rsiValues: [55],
+        divergences: [],
+        latestDivergence: null,
+        hasBullishDivergence: false,
+        hasBearishDivergence: false,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.RSI_DIVERGENCE],
+      });
+
+      expect(result.indicators.patterns?.rsiDivergence?.type).toBeNull();
+      expect(result.indicators.patterns?.rsiDivergence?.strength).toBeNull();
+    });
+
+    it('should handle chart patterns with no patterns detected', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      mockIndicatorsService.detectChartPatterns.mockReturnValue({
+        lookbackPeriod: 50,
+        patterns: [],
+        bullishPatterns: [],
+        bearishPatterns: [],
+        latestPattern: null,
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.CHART_PATTERNS],
+      });
+
+      expect(result.indicators.patterns?.chartPatterns?.direction).toBeNull();
+    });
+
+    it('should handle addSignalFromIndicator with null values', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      // Return indicators that don't contribute to signals
+      mockIndicatorsService.calculateVwap.mockReturnValue({
+        values: [100],
+        latestValue: 100, // Same as current price - no signal
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.VWAP],
+      });
+
+      // VWAP should be included but position is based on comparison
+      expect(result.indicators.volume?.vwap).toBeDefined();
+    });
+
+    it('should handle candlestick patterns neutral bias (neither bullish nor bearish)', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      // Candlestick patterns with no bullish or bearish bias
+      mockIndicatorsService.detectCandlestickPatterns.mockReturnValue({
+        bullish: false,
+        bearish: false,
+        patterns: [],
+        detectedPatterns: ['Doji'], // Neutral pattern
+      });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.CANDLESTICK_PATTERNS],
+      });
+
+      expect(result.indicators.patterns?.candlestickPatterns?.bias).toBe(
+        'neutral',
+      );
+    });
+
+    it('should handle MACD crossover with null previous values', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed.mockResolvedValue({
+        candles: mockCandles,
+      });
+
+      // MACD with null values in previous entry
+      mockIndicatorsService.calculateMacd.mockReturnValue({
+        fastPeriod: 12,
+        slowPeriod: 26,
+        signalPeriod: 9,
+        values: [
+          { MACD: undefined, signal: undefined, histogram: 0 },
+          { MACD: 1.5, signal: 1.0, histogram: 0.5 },
+        ],
+        latestValue: { MACD: 1.5, signal: 1.0, histogram: 0.5 },
+      } as unknown as ReturnType<typeof mockIndicatorsService.calculateMacd>);
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.MACD],
+      });
+
+      // Should handle null previous values with defaults
+      expect(result.indicators.momentum?.macd).toBeDefined();
+    });
+
+    it('should handle fetchDailyCandles with null candles response', async () => {
+      const mockCandles = createMockCandles(100);
+      mockProductsService.getProductCandlesFixed
+        .mockResolvedValueOnce({ candles: mockCandles })
+        .mockResolvedValueOnce({
+          candles: undefined, // Null candles array
+        } as unknown as {
+          candles: {
+            open: string;
+            high: string;
+            low: string;
+            close: string;
+            volume: string;
+          }[];
+        });
+
+      const result = await service.analyzeTechnicalIndicators({
+        productId: 'BTC-USD',
+        granularity: Granularity.ONE_HOUR,
+        indicators: [IndicatorType.PIVOT_POINTS],
+      });
+
+      // Should handle null candles with empty array default
+      // Pivot points won't be calculated since we don't have enough daily candles
+      expect(result.indicators.supportResistance?.pivotPoints).toBeUndefined();
+    });
+  });
+});

--- a/src/server/TechnicalAnalysisService.ts
+++ b/src/server/TechnicalAnalysisService.ts
@@ -1,0 +1,1096 @@
+/**
+ * Technical Analysis Service.
+ *
+ * Provides integrated candle fetching and indicator calculation,
+ * reducing context usage by keeping candle data server-side and
+ * returning only computed indicator values.
+ */
+
+import type { ProductsService } from './ProductsService';
+import type {
+  TechnicalIndicatorsService,
+  CandleInput,
+} from './TechnicalIndicatorsService';
+import { Granularity } from './ProductCandles';
+import {
+  AnalyzeTechnicalIndicatorsRequest,
+  AnalyzeTechnicalIndicatorsResponse,
+  IndicatorType,
+  MomentumIndicators,
+  TrendIndicators,
+  VolatilityIndicators,
+  VolumeIndicators,
+  PatternIndicators,
+  SupportResistanceIndicators,
+  PriceSummary,
+  AggregatedSignal,
+  SignalDirection,
+  SignalConfidence,
+  IndicatorResults,
+} from './TechnicalAnalysis';
+
+/** Default number of candles to fetch */
+const DEFAULT_CANDLE_COUNT = 100;
+
+/** Minimum candles required for meaningful analysis */
+const MIN_CANDLE_COUNT = 5;
+
+/** Maximum candles to prevent excessive API usage */
+const MAX_CANDLE_COUNT = 300;
+
+/** Granularity values in seconds for time calculation */
+const GRANULARITY_SECONDS: Record<Granularity, number> = {
+  [Granularity.ONE_MINUTE]: 60,
+  [Granularity.FIVE_MINUTE]: 300,
+  [Granularity.FIFTEEN_MINUTE]: 900,
+  [Granularity.THIRTY_MINUTE]: 1800,
+  [Granularity.ONE_HOUR]: 3600,
+  [Granularity.TWO_HOUR]: 7200,
+  [Granularity.SIX_HOUR]: 21600,
+  [Granularity.ONE_DAY]: 86400,
+};
+
+/**
+ * Service for integrated technical analysis.
+ *
+ * Combines candle fetching and indicator calculation to reduce
+ * context usage. Candle data never leaves the server - only
+ * computed indicator values are returned.
+ */
+export class TechnicalAnalysisService {
+  constructor(
+    private readonly productsService: ProductsService,
+    private readonly indicatorsService: TechnicalIndicatorsService,
+  ) {}
+
+  /**
+   * Analyze technical indicators for a product.
+   *
+   * Fetches candles internally and calculates all requested indicators.
+   * Returns aggregated results without raw candle data.
+   *
+   * @param request - Product ID, granularity, and optional settings
+   * @returns Indicator results with aggregated signal
+   */
+  public async analyzeTechnicalIndicators(
+    request: AnalyzeTechnicalIndicatorsRequest,
+  ): Promise<AnalyzeTechnicalIndicatorsResponse> {
+    const candleCount = this.validateCandleCount(request.candleCount);
+    const indicators = request.indicators ?? Object.values(IndicatorType);
+
+    // Fetch main candles for the requested timeframe
+    const candles = await this.fetchCandles(
+      request.productId,
+      request.granularity,
+      candleCount,
+    );
+
+    // Build price summary from candles
+    const price = this.buildPriceSummary(candles);
+
+    // Calculate indicators
+    const indicatorResults = await this.calculateIndicators(
+      request.productId,
+      candles,
+      indicators,
+    );
+
+    // Calculate aggregated signal
+    const signal = this.calculateAggregatedSignal(indicatorResults);
+
+    return {
+      productId: request.productId,
+      granularity: request.granularity,
+      candleCount: candles.length,
+      timestamp: new Date().toISOString(),
+      price,
+      indicators: indicatorResults,
+      signal,
+    };
+  }
+
+  /**
+   * Validate and normalize candle count.
+   */
+  private validateCandleCount(count: number | undefined): number {
+    const value = count ?? DEFAULT_CANDLE_COUNT;
+    return Math.min(Math.max(value, MIN_CANDLE_COUNT), MAX_CANDLE_COUNT);
+  }
+
+  /**
+   * Fetch candles for the requested timeframe.
+   */
+  private async fetchCandles(
+    productId: string,
+    granularity: Granularity,
+    candleCount: number,
+  ): Promise<CandleInput[]> {
+    const end = new Date();
+    const secondsPerCandle = GRANULARITY_SECONDS[granularity];
+    const start = new Date(
+      end.getTime() - candleCount * secondsPerCandle * 1000,
+    );
+
+    const response = await this.productsService.getProductCandlesFixed({
+      productId,
+      granularity,
+      start: start.toISOString(),
+      end: end.toISOString(),
+    });
+
+    return mapApiCandlesToInput(response.candles);
+  }
+
+  /**
+   * Fetch daily candles for pivot points calculation.
+   * Uses previous trading day's OHLC (industry standard).
+   */
+  private async fetchDailyCandles(productId: string): Promise<CandleInput[]> {
+    // Fetch 3 days to ensure we have the previous complete day
+    const end = new Date();
+    const start = new Date(end.getTime() - 3 * 24 * 60 * 60 * 1000);
+
+    const response = await this.productsService.getProductCandlesFixed({
+      productId,
+      granularity: Granularity.ONE_DAY,
+      start: start.toISOString(),
+      end: end.toISOString(),
+    });
+
+    return mapApiCandlesToInput(response.candles);
+  }
+
+  /**
+   * Build price summary from candle data.
+   */
+  private buildPriceSummary(candles: readonly CandleInput[]): PriceSummary {
+    if (candles.length === 0) {
+      return {
+        current: 0,
+        open: 0,
+        high: 0,
+        low: 0,
+        change24h: 0,
+      };
+    }
+
+    // Coinbase returns candles newest first
+    const latest = candles[0];
+    const oldest = candles[candles.length - 1];
+
+    const current = parseFloat(latest.close);
+    const open = parseFloat(oldest.open);
+    const high = Math.max(...candles.map((c) => parseFloat(c.high)));
+    const low = Math.min(...candles.map((c) => parseFloat(c.low)));
+    const change24h = open !== 0 ? ((current - open) / open) * 100 : 0;
+
+    return {
+      current,
+      open,
+      high,
+      low,
+      change24h,
+    };
+  }
+
+  /**
+   * Calculate all requested indicators.
+   */
+  private async calculateIndicators(
+    productId: string,
+    candles: readonly CandleInput[],
+    indicators: readonly IndicatorType[],
+  ): Promise<IndicatorResults> {
+    const indicatorSet = new Set(indicators);
+
+    const results: IndicatorResults = {};
+
+    // Calculate momentum indicators
+    const momentum = this.calculateMomentumIndicators(candles, indicatorSet);
+    if (Object.keys(momentum).length > 0) {
+      results.momentum = momentum;
+    }
+
+    // Calculate trend indicators
+    const trend = this.calculateTrendIndicators(candles, indicatorSet);
+    if (Object.keys(trend).length > 0) {
+      results.trend = trend;
+    }
+
+    // Calculate volatility indicators
+    const volatility = this.calculateVolatilityIndicators(
+      candles,
+      indicatorSet,
+    );
+    if (Object.keys(volatility).length > 0) {
+      results.volatility = volatility;
+    }
+
+    // Calculate volume indicators
+    const volume = this.calculateVolumeIndicators(candles, indicatorSet);
+    if (Object.keys(volume).length > 0) {
+      results.volume = volume;
+    }
+
+    // Calculate pattern detection
+    const patterns = this.calculatePatternIndicators(candles, indicatorSet);
+    if (Object.keys(patterns).length > 0) {
+      results.patterns = patterns;
+    }
+
+    // Calculate support/resistance (may require additional API calls)
+    const supportResistance = await this.calculateSupportResistanceIndicators(
+      productId,
+      candles,
+      indicatorSet,
+    );
+    if (Object.keys(supportResistance).length > 0) {
+      results.supportResistance = supportResistance;
+    }
+
+    return results;
+  }
+
+  /**
+   * Calculate momentum indicators (RSI, MACD, Stochastic, ADX, CCI, Williams %R, ROC).
+   */
+  private calculateMomentumIndicators(
+    candles: readonly CandleInput[],
+    indicatorSet: Set<IndicatorType>,
+  ): MomentumIndicators {
+    const momentum: MomentumIndicators = {};
+
+    if (indicatorSet.has(IndicatorType.RSI)) {
+      const result = this.indicatorsService.calculateRsi({ candles });
+      if (result.latestValue !== null) {
+        momentum.rsi = {
+          value: result.latestValue,
+          signal: this.interpretRsi(result.latestValue),
+        };
+      }
+    }
+
+    if (indicatorSet.has(IndicatorType.MACD)) {
+      const result = this.indicatorsService.calculateMacd({ candles });
+      if (result.latestValue?.MACD !== undefined) {
+        const macd = result.latestValue.MACD;
+        const signal = result.latestValue.signal ?? 0;
+        const histogram = result.latestValue.histogram ?? 0;
+        momentum.macd = {
+          macd,
+          signal,
+          histogram,
+          crossover: this.interpretMacdCrossover(macd, signal, result.values),
+        };
+      }
+    }
+
+    if (indicatorSet.has(IndicatorType.STOCHASTIC)) {
+      const result = this.indicatorsService.calculateStochastic({ candles });
+      if (result.latestValue) {
+        momentum.stochastic = {
+          k: result.latestValue.k,
+          d: result.latestValue.d,
+          signal: this.interpretStochastic(result.latestValue.k),
+        };
+      }
+    }
+
+    if (indicatorSet.has(IndicatorType.ADX)) {
+      const result = this.indicatorsService.calculateAdx({ candles });
+      if (result.latestValue) {
+        momentum.adx = {
+          adx: result.latestValue.adx,
+          pdi: result.latestValue.pdi,
+          mdi: result.latestValue.mdi,
+          trendStrength: this.interpretAdx(result.latestValue.adx),
+        };
+      }
+    }
+
+    if (indicatorSet.has(IndicatorType.CCI)) {
+      const result = this.indicatorsService.calculateCci({ candles });
+      if (result.latestValue !== null) {
+        momentum.cci = {
+          value: result.latestValue,
+          signal: this.interpretCci(result.latestValue),
+        };
+      }
+    }
+
+    if (indicatorSet.has(IndicatorType.WILLIAMS_R)) {
+      const result = this.indicatorsService.calculateWilliamsR({ candles });
+      if (result.latestValue !== null) {
+        momentum.williamsR = {
+          value: result.latestValue,
+          signal: this.interpretWilliamsR(result.latestValue),
+        };
+      }
+    }
+
+    if (indicatorSet.has(IndicatorType.ROC)) {
+      const result = this.indicatorsService.calculateRoc({ candles });
+      if (result.latestValue !== null) {
+        momentum.roc = {
+          value: result.latestValue,
+          signal: this.interpretRoc(result.latestValue),
+        };
+      }
+    }
+
+    return momentum;
+  }
+
+  /**
+   * Calculate trend indicators (SMA, EMA, Ichimoku, PSAR).
+   */
+  private calculateTrendIndicators(
+    candles: readonly CandleInput[],
+    indicatorSet: Set<IndicatorType>,
+  ): TrendIndicators {
+    const trend: TrendIndicators = {};
+    const currentPrice = candles.length > 0 ? parseFloat(candles[0].close) : 0;
+
+    if (indicatorSet.has(IndicatorType.SMA)) {
+      const result = this.indicatorsService.calculateSma({ candles });
+      if (result.latestValue !== null) {
+        trend.sma = {
+          value: result.latestValue,
+          trend: currentPrice > result.latestValue ? 'bullish' : 'bearish',
+        };
+      }
+    }
+
+    if (indicatorSet.has(IndicatorType.EMA)) {
+      const result = this.indicatorsService.calculateEma({ candles });
+      if (result.latestValue !== null) {
+        trend.ema = {
+          value: result.latestValue,
+          trend: currentPrice > result.latestValue ? 'bullish' : 'bearish',
+        };
+      }
+    }
+
+    if (indicatorSet.has(IndicatorType.ICHIMOKU) && candles.length >= 52) {
+      const result = this.indicatorsService.calculateIchimokuCloud({ candles });
+      if (result.latestValue) {
+        trend.ichimoku = {
+          tenkan: result.latestValue.conversion,
+          kijun: result.latestValue.base,
+          senkouA: result.latestValue.spanA,
+          senkouB: result.latestValue.spanB,
+          signal: this.interpretIchimoku(
+            currentPrice,
+            result.latestValue.spanA,
+            result.latestValue.spanB,
+          ),
+        };
+      }
+    }
+
+    if (indicatorSet.has(IndicatorType.PSAR)) {
+      const result = this.indicatorsService.calculatePsar({ candles });
+      if (result.latestValue !== null) {
+        trend.psar = {
+          value: result.latestValue,
+          trend: currentPrice > result.latestValue ? 'up' : 'down',
+        };
+      }
+    }
+
+    return trend;
+  }
+
+  /**
+   * Calculate volatility indicators (Bollinger Bands, ATR, Keltner).
+   */
+  private calculateVolatilityIndicators(
+    candles: readonly CandleInput[],
+    indicatorSet: Set<IndicatorType>,
+  ): VolatilityIndicators {
+    const volatility: VolatilityIndicators = {};
+    const currentPrice = candles.length > 0 ? parseFloat(candles[0].close) : 0;
+
+    if (indicatorSet.has(IndicatorType.BOLLINGER_BANDS)) {
+      const result = this.indicatorsService.calculateBollingerBands({
+        candles,
+      });
+      if (result.latestValue) {
+        volatility.bollingerBands = {
+          upper: result.latestValue.upper,
+          middle: result.latestValue.middle,
+          lower: result.latestValue.lower,
+          percentB: result.latestValue.pb,
+          signal: this.interpretBollingerBands(result.latestValue.pb),
+        };
+      }
+    }
+
+    if (indicatorSet.has(IndicatorType.ATR)) {
+      const result = this.indicatorsService.calculateAtr({ candles });
+      if (result.latestValue !== null) {
+        const atrPercent =
+          currentPrice > 0 ? (result.latestValue / currentPrice) * 100 : 0;
+        volatility.atr = {
+          value: result.latestValue,
+          volatility: this.interpretAtr(atrPercent),
+        };
+      }
+    }
+
+    if (indicatorSet.has(IndicatorType.KELTNER) && candles.length >= 20) {
+      const result = this.indicatorsService.calculateKeltnerChannels({
+        candles,
+      });
+      if (result.latestValue) {
+        volatility.keltner = {
+          upper: result.latestValue.upper,
+          middle: result.latestValue.middle,
+          lower: result.latestValue.lower,
+          signal: this.interpretKeltner(
+            currentPrice,
+            result.latestValue.upper,
+            result.latestValue.lower,
+          ),
+        };
+      }
+    }
+
+    return volatility;
+  }
+
+  /**
+   * Calculate volume indicators (OBV, MFI, VWAP, Volume Profile).
+   */
+  private calculateVolumeIndicators(
+    candles: readonly CandleInput[],
+    indicatorSet: Set<IndicatorType>,
+  ): VolumeIndicators {
+    const volume: VolumeIndicators = {};
+    const currentPrice = candles.length > 0 ? parseFloat(candles[0].close) : 0;
+
+    if (indicatorSet.has(IndicatorType.OBV)) {
+      const result = this.indicatorsService.calculateObv({ candles });
+      if (result.values.length >= 2) {
+        const latest = result.values[result.values.length - 1];
+        const previous = result.values[result.values.length - 2];
+        volume.obv = {
+          value: latest,
+          trend:
+            latest > previous
+              ? 'rising'
+              : latest < previous
+                ? 'falling'
+                : 'flat',
+        };
+      }
+    }
+
+    if (indicatorSet.has(IndicatorType.MFI)) {
+      const result = this.indicatorsService.calculateMfi({ candles });
+      if (result.latestValue !== null) {
+        volume.mfi = {
+          value: result.latestValue,
+          signal: this.interpretMfi(result.latestValue),
+        };
+      }
+    }
+
+    if (indicatorSet.has(IndicatorType.VWAP)) {
+      const result = this.indicatorsService.calculateVwap({ candles });
+      if (result.latestValue !== null) {
+        volume.vwap = {
+          value: result.latestValue,
+          position: currentPrice > result.latestValue ? 'above' : 'below',
+        };
+      }
+    }
+
+    if (indicatorSet.has(IndicatorType.VOLUME_PROFILE)) {
+      const result = this.indicatorsService.calculateVolumeProfile({ candles });
+      if (result.pointOfControl) {
+        volume.volumeProfile = {
+          poc: result.pointOfControl.rangeEnd,
+          valueAreaHigh: result.valueAreaHigh ?? 0,
+          valueAreaLow: result.valueAreaLow ?? 0,
+        };
+      }
+    }
+
+    return volume;
+  }
+
+  /**
+   * Calculate pattern detection indicators.
+   */
+  private calculatePatternIndicators(
+    candles: readonly CandleInput[],
+    indicatorSet: Set<IndicatorType>,
+  ): PatternIndicators {
+    const patterns: PatternIndicators = {};
+
+    if (indicatorSet.has(IndicatorType.CANDLESTICK_PATTERNS)) {
+      const result = this.indicatorsService.detectCandlestickPatterns({
+        candles,
+      });
+      patterns.candlestickPatterns = {
+        patterns: result.detectedPatterns,
+        bias: result.bullish
+          ? 'bullish'
+          : result.bearish
+            ? 'bearish'
+            : 'neutral',
+      };
+    }
+
+    if (indicatorSet.has(IndicatorType.RSI_DIVERGENCE)) {
+      const result = this.indicatorsService.detectRsiDivergence({ candles });
+      patterns.rsiDivergence = {
+        type: result.latestDivergence?.type ?? null,
+        strength: result.latestDivergence?.strength ?? null,
+      };
+    }
+
+    if (
+      indicatorSet.has(IndicatorType.CHART_PATTERNS) &&
+      candles.length >= 50
+    ) {
+      const result = this.indicatorsService.detectChartPatterns({ candles });
+      patterns.chartPatterns = {
+        patterns: result.patterns.map((p) => p.type),
+        direction:
+          result.bullishPatterns.length > result.bearishPatterns.length
+            ? 'bullish'
+            : result.bearishPatterns.length > result.bullishPatterns.length
+              ? 'bearish'
+              : null,
+      };
+    }
+
+    if (indicatorSet.has(IndicatorType.SWING_POINTS)) {
+      const result = this.indicatorsService.detectSwingPoints({ candles });
+      patterns.swingPoints = {
+        latestSwingHigh: result.latestSwingHigh?.price ?? null,
+        latestSwingLow: result.latestSwingLow?.price ?? null,
+        trend: result.trend,
+        swingHighCount: result.swingHighs.length,
+        swingLowCount: result.swingLows.length,
+      };
+    }
+
+    return patterns;
+  }
+
+  /**
+   * Calculate support/resistance indicators (Pivot Points, Fibonacci).
+   */
+  private async calculateSupportResistanceIndicators(
+    productId: string,
+    candles: readonly CandleInput[],
+    indicatorSet: Set<IndicatorType>,
+  ): Promise<SupportResistanceIndicators> {
+    const supportResistance: SupportResistanceIndicators = {};
+
+    // Pivot Points: Use daily candles (industry standard)
+    if (indicatorSet.has(IndicatorType.PIVOT_POINTS)) {
+      try {
+        const dailyCandles = await this.fetchDailyCandles(productId);
+        // Use previous day (index 1, since index 0 is current incomplete day)
+        if (dailyCandles.length >= 2) {
+          const previousDay = dailyCandles[1];
+          const result = this.indicatorsService.calculatePivotPoints({
+            high: previousDay.high,
+            low: previousDay.low,
+            close: previousDay.close,
+            open: previousDay.open,
+          });
+          // Standard pivot points have all levels
+          if (result.type === 'standard' || result.type === 'fibonacci') {
+            supportResistance.pivotPoints = {
+              pivot: result.pivotPoint,
+              r1: result.resistance1,
+              r2: result.resistance2,
+              r3: result.resistance3,
+              s1: result.support1,
+              s2: result.support2,
+              s3: result.support3,
+              source: 'daily',
+            };
+          } else if (result.type === 'camarilla') {
+            supportResistance.pivotPoints = {
+              pivot: result.pivotPoint,
+              r1: result.resistance1,
+              r2: result.resistance2,
+              r3: result.resistance3,
+              s1: result.support1,
+              s2: result.support2,
+              s3: result.support3,
+              source: 'daily',
+            };
+          } else if (result.type === 'woodie') {
+            supportResistance.pivotPoints = {
+              pivot: result.pivotPoint,
+              r1: result.resistance1,
+              r2: result.resistance2,
+              r3: 0,
+              s1: result.support1,
+              s2: result.support2,
+              s3: 0,
+              source: 'daily',
+            };
+          } else {
+            // demark type
+            supportResistance.pivotPoints = {
+              pivot: result.pivotPoint,
+              r1: result.resistance1,
+              r2: 0,
+              r3: 0,
+              s1: result.support1,
+              s2: 0,
+              s3: 0,
+              source: 'daily',
+            };
+          }
+        }
+      } catch {
+        // Pivot points calculation failed, skip
+      }
+    }
+
+    // Fibonacci: Use swing points (industry standard)
+    if (indicatorSet.has(IndicatorType.FIBONACCI)) {
+      const swings = this.indicatorsService.detectSwingPoints({ candles });
+      if (swings.latestSwingHigh && swings.latestSwingLow) {
+        const isUptrend = swings.trend === 'uptrend';
+        const start = isUptrend
+          ? swings.latestSwingLow.price
+          : swings.latestSwingHigh.price;
+        const end = isUptrend
+          ? swings.latestSwingHigh.price
+          : swings.latestSwingLow.price;
+
+        const result = this.indicatorsService.calculateFibonacciRetracement({
+          start,
+          end,
+        });
+
+        const levels: Record<string, number> = {};
+        for (const level of result.levels) {
+          levels[`${level.level}%`] = level.price;
+        }
+
+        supportResistance.fibonacci = {
+          trend: result.trend,
+          levels,
+          swingHigh: swings.latestSwingHigh.price,
+          swingLow: swings.latestSwingLow.price,
+        };
+      }
+    }
+
+    return supportResistance;
+  }
+
+  /**
+   * Calculate aggregated signal from all indicator results.
+   */
+  private calculateAggregatedSignal(
+    indicators: IndicatorResults,
+  ): AggregatedSignal {
+    let bullishSignals = 0;
+    let bearishSignals = 0;
+    let totalSignals = 0;
+
+    // Count momentum signals
+    if (indicators.momentum) {
+      const m = indicators.momentum;
+      if (m.rsi) {
+        totalSignals++;
+        if (m.rsi.signal === 'oversold') {
+          bullishSignals++;
+        } else if (m.rsi.signal === 'overbought') {
+          bearishSignals++;
+        }
+      }
+      if (m.macd) {
+        totalSignals++;
+        if (m.macd.crossover === 'bullish') {
+          bullishSignals++;
+        } else if (m.macd.crossover === 'bearish') {
+          bearishSignals++;
+        }
+      }
+      if (m.stochastic) {
+        totalSignals++;
+        if (m.stochastic.signal === 'oversold') {
+          bullishSignals++;
+        } else if (m.stochastic.signal === 'overbought') {
+          bearishSignals++;
+        }
+      }
+      if (m.adx) {
+        totalSignals++;
+        if (m.adx.pdi > m.adx.mdi) {
+          bullishSignals++;
+        } else if (m.adx.mdi > m.adx.pdi) {
+          bearishSignals++;
+        }
+      }
+      if (m.cci) {
+        totalSignals++;
+        if (m.cci.signal === 'oversold') {
+          bullishSignals++;
+        } else if (m.cci.signal === 'overbought') {
+          bearishSignals++;
+        }
+      }
+      if (m.williamsR) {
+        totalSignals++;
+        if (m.williamsR.signal === 'oversold') {
+          bullishSignals++;
+        } else if (m.williamsR.signal === 'overbought') {
+          bearishSignals++;
+        }
+      }
+      if (m.roc) {
+        totalSignals++;
+        if (m.roc.signal === 'bullish') {
+          bullishSignals++;
+        } else if (m.roc.signal === 'bearish') {
+          bearishSignals++;
+        }
+      }
+    }
+
+    // Count trend signals
+    if (indicators.trend) {
+      const t = indicators.trend;
+      if (t.sma) {
+        totalSignals++;
+        if (t.sma.trend === 'bullish') {
+          bullishSignals++;
+        } else {
+          bearishSignals++;
+        }
+      }
+      if (t.ema) {
+        totalSignals++;
+        if (t.ema.trend === 'bullish') {
+          bullishSignals++;
+        } else {
+          bearishSignals++;
+        }
+      }
+      if (t.ichimoku) {
+        totalSignals++;
+        if (t.ichimoku.signal === 'bullish') {
+          bullishSignals++;
+        } else if (t.ichimoku.signal === 'bearish') {
+          bearishSignals++;
+        }
+      }
+      if (t.psar) {
+        totalSignals++;
+        if (t.psar.trend === 'up') {
+          bullishSignals++;
+        } else {
+          bearishSignals++;
+        }
+      }
+    }
+
+    // Count volatility signals
+    if (indicators.volatility?.bollingerBands) {
+      totalSignals++;
+      if (indicators.volatility.bollingerBands.signal === 'oversold') {
+        bullishSignals++;
+      } else if (indicators.volatility.bollingerBands.signal === 'overbought') {
+        bearishSignals++;
+      }
+    }
+
+    // Count volume signals
+    if (indicators.volume) {
+      const v = indicators.volume;
+      if (v.obv) {
+        totalSignals++;
+        if (v.obv.trend === 'rising') {
+          bullishSignals++;
+        } else if (v.obv.trend === 'falling') {
+          bearishSignals++;
+        }
+      }
+      if (v.mfi) {
+        totalSignals++;
+        if (v.mfi.signal === 'oversold') {
+          bullishSignals++;
+        } else if (v.mfi.signal === 'overbought') {
+          bearishSignals++;
+        }
+      }
+      if (v.vwap) {
+        totalSignals++;
+        if (v.vwap.position === 'above') {
+          bullishSignals++;
+        } else {
+          bearishSignals++;
+        }
+      }
+    }
+
+    // Count pattern signals
+    if (indicators.patterns) {
+      const p = indicators.patterns;
+      if (p.candlestickPatterns) {
+        totalSignals++;
+        if (p.candlestickPatterns.bias === 'bullish') {
+          bullishSignals++;
+        } else if (p.candlestickPatterns.bias === 'bearish') {
+          bearishSignals++;
+        }
+      }
+      if (p.rsiDivergence?.type) {
+        totalSignals++;
+        if (p.rsiDivergence.type.includes('bullish')) {
+          bullishSignals++;
+        } else if (p.rsiDivergence.type.includes('bearish')) {
+          bearishSignals++;
+        }
+      }
+      if (p.chartPatterns?.direction) {
+        totalSignals++;
+        if (p.chartPatterns.direction === 'bullish') {
+          bullishSignals++;
+        } else {
+          bearishSignals++;
+        }
+      }
+      if (p.swingPoints) {
+        totalSignals++;
+        if (p.swingPoints.trend === 'uptrend') {
+          bullishSignals++;
+        } else if (p.swingPoints.trend === 'downtrend') {
+          bearishSignals++;
+        }
+      }
+    }
+
+    // Calculate score (-100 to +100)
+    const score =
+      totalSignals > 0
+        ? Math.round(((bullishSignals - bearishSignals) / totalSignals) * 100)
+        : 0;
+
+    // Determine direction
+    const direction = this.scoreToDirection(score);
+
+    // Determine confidence
+    const agreementRate =
+      totalSignals > 0
+        ? Math.max(bullishSignals, bearishSignals) / totalSignals
+        : 0;
+    const confidence = this.agreementToConfidence(agreementRate, totalSignals);
+
+    return { score, direction, confidence };
+  }
+
+  // ============================================================================
+  // Interpretation Helpers
+  // ============================================================================
+
+  private interpretRsi(value: number): string {
+    if (value >= 70) {
+      return 'overbought';
+    }
+    if (value <= 30) {
+      return 'oversold';
+    }
+    return 'neutral';
+  }
+
+  private interpretMacdCrossover(
+    macd: number,
+    signal: number,
+    values: readonly { MACD?: number; signal?: number }[],
+  ): string {
+    if (values.length < 2) {
+      return 'none';
+    }
+    const prev = values[values.length - 2];
+    const prevMacd = prev.MACD ?? 0;
+    const prevSignal = prev.signal ?? 0;
+
+    if (macd > signal && prevMacd <= prevSignal) {
+      return 'bullish';
+    }
+    if (macd < signal && prevMacd >= prevSignal) {
+      return 'bearish';
+    }
+    return 'none';
+  }
+
+  private interpretStochastic(k: number): string {
+    if (k >= 80) {
+      return 'overbought';
+    }
+    if (k <= 20) {
+      return 'oversold';
+    }
+    return 'neutral';
+  }
+
+  private interpretAdx(adx: number): string {
+    if (adx >= 25) {
+      return 'strong';
+    }
+    if (adx >= 20) {
+      return 'moderate';
+    }
+    return 'weak';
+  }
+
+  private interpretCci(value: number): string {
+    if (value >= 100) {
+      return 'overbought';
+    }
+    if (value <= -100) {
+      return 'oversold';
+    }
+    return 'neutral';
+  }
+
+  private interpretWilliamsR(value: number): string {
+    if (value >= -20) {
+      return 'overbought';
+    }
+    if (value <= -80) {
+      return 'oversold';
+    }
+    return 'neutral';
+  }
+
+  private interpretRoc(value: number): string {
+    if (value > 0) {
+      return 'bullish';
+    }
+    if (value < 0) {
+      return 'bearish';
+    }
+    return 'neutral';
+  }
+
+  private interpretIchimoku(
+    price: number,
+    spanA: number,
+    spanB: number,
+  ): string {
+    const cloudTop = Math.max(spanA, spanB);
+    const cloudBottom = Math.min(spanA, spanB);
+    if (price > cloudTop) {
+      return 'bullish';
+    }
+    if (price < cloudBottom) {
+      return 'bearish';
+    }
+    return 'neutral';
+  }
+
+  private interpretBollingerBands(percentB: number): string {
+    if (percentB >= 1) {
+      return 'overbought';
+    }
+    if (percentB <= 0) {
+      return 'oversold';
+    }
+    return 'neutral';
+  }
+
+  private interpretAtr(atrPercent: number): string {
+    if (atrPercent >= 3) {
+      return 'high';
+    }
+    if (atrPercent >= 1.5) {
+      return 'normal';
+    }
+    return 'low';
+  }
+
+  private interpretKeltner(
+    price: number,
+    upper: number,
+    lower: number,
+  ): string {
+    if (price >= upper) {
+      return 'overbought';
+    }
+    if (price <= lower) {
+      return 'oversold';
+    }
+    return 'neutral';
+  }
+
+  private interpretMfi(value: number): string {
+    if (value >= 80) {
+      return 'overbought';
+    }
+    if (value <= 20) {
+      return 'oversold';
+    }
+    return 'neutral';
+  }
+
+  private scoreToDirection(score: number): SignalDirection {
+    if (score >= 50) {
+      return 'STRONG_BUY';
+    }
+    if (score >= 20) {
+      return 'BUY';
+    }
+    if (score <= -50) {
+      return 'STRONG_SELL';
+    }
+    if (score <= -20) {
+      return 'SELL';
+    }
+    return 'NEUTRAL';
+  }
+
+  private agreementToConfidence(
+    rate: number,
+    totalSignals: number,
+  ): SignalConfidence {
+    if (totalSignals < 5) {
+      return 'LOW';
+    }
+    if (rate >= 0.75) {
+      return 'HIGH';
+    }
+    if (rate >= 0.5) {
+      return 'MEDIUM';
+    }
+    return 'LOW';
+  }
+}
+
+/**
+ * Map API candle response to CandleInput format.
+ */
+function mapApiCandlesToInput(
+  candles:
+    | ReadonlyArray<{
+        readonly open?: string;
+        readonly high?: string;
+        readonly low?: string;
+        readonly close?: string;
+        readonly volume?: string;
+      }>
+    | undefined,
+): CandleInput[] {
+  return (candles ?? []).map((c) => ({
+    open: c.open ?? '0',
+    high: c.high ?? '0',
+    low: c.low ?? '0',
+    close: c.close ?? '0',
+    volume: c.volume ?? '0',
+  }));
+}

--- a/src/server/TechnicalIndicatorsService.spec.ts
+++ b/src/server/TechnicalIndicatorsService.spec.ts
@@ -2709,4 +2709,55 @@ describe('TechnicalIndicatorsService', () => {
       ).toBe(true);
     });
   });
+
+  describe('detectSwingPoints', () => {
+    it('should detect swing highs and lows using Williams Fractal', () => {
+      // Pattern: swing high in the middle
+      const candles: CandleInput[] = [
+        { open: '100', high: '105', low: '95', close: '102', volume: '1000' },
+        { open: '102', high: '108', low: '100', close: '105', volume: '1000' },
+        { open: '105', high: '112', low: '103', close: '110', volume: '1000' },
+        { open: '110', high: '108', low: '106', close: '107', volume: '1000' },
+        { open: '107', high: '106', low: '102', close: '104', volume: '1000' },
+      ];
+
+      const result = service.detectSwingPoints({ candles });
+
+      expect(result.swingHighs.length).toBeGreaterThanOrEqual(0);
+      expect(result.swingLows.length).toBeGreaterThanOrEqual(0);
+      expect(['uptrend', 'downtrend', 'sideways']).toContain(result.trend);
+    });
+
+    it('should use default lookback of 2 when not specified', () => {
+      const candles: CandleInput[] = Array.from({ length: 10 }, (_, i) => ({
+        open: String(100 + i),
+        high: String(105 + i),
+        low: String(95 + i),
+        close: String(102 + i),
+        volume: '1000',
+      }));
+
+      const result = service.detectSwingPoints({ candles });
+
+      // Should return valid response
+      expect(result).toHaveProperty('swingHighs');
+      expect(result).toHaveProperty('swingLows');
+      expect(result).toHaveProperty('trend');
+    });
+
+    it('should use custom lookback when specified', () => {
+      const candles: CandleInput[] = Array.from({ length: 7 }, (_, i) => ({
+        open: String(100 + i),
+        high: String(105 + i),
+        low: String(95 + i),
+        close: String(102 + i),
+        volume: '1000',
+      }));
+
+      const result = service.detectSwingPoints({ candles, lookback: 3 });
+
+      expect(result).toHaveProperty('swingHighs');
+      expect(result).toHaveProperty('swingLows');
+    });
+  });
 });

--- a/src/server/TechnicalIndicatorsService.ts
+++ b/src/server/TechnicalIndicatorsService.ts
@@ -78,6 +78,11 @@ import {
 } from './indicators/volumeProfile';
 
 import { detectChartPatterns, ChartPattern } from './indicators/chartPatterns';
+import {
+  detectSwingPoints,
+  SwingPoint,
+  SwingTrend,
+} from './indicators/swingPoints';
 
 /**
  * Candle data structure matching Coinbase API output.
@@ -599,6 +604,25 @@ export interface DetectChartPatternsOutput {
   readonly bullishPatterns: readonly ChartPattern[];
   readonly bearishPatterns: readonly ChartPattern[];
   readonly latestPattern: ChartPattern | null;
+}
+
+/**
+ * Input for Swing Points detection (Williams Fractal)
+ */
+export interface DetectSwingPointsInput {
+  readonly candles: readonly CandleInput[];
+  readonly lookback?: number;
+}
+
+/**
+ * Output for Swing Points detection (Williams Fractal)
+ */
+export interface DetectSwingPointsOutput {
+  readonly swingHighs: readonly SwingPoint[];
+  readonly swingLows: readonly SwingPoint[];
+  readonly latestSwingHigh: SwingPoint | null;
+  readonly latestSwingLow: SwingPoint | null;
+  readonly trend: SwingTrend;
 }
 
 const DEFAULT_RSI_PERIOD = 14;
@@ -1449,6 +1473,30 @@ export class TechnicalIndicatorsService {
       bearishPatterns,
       latestPattern,
     };
+  }
+
+  /**
+   * Detect swing points using Williams Fractal method.
+   *
+   * A swing high occurs when a bar's high is higher than the highs of
+   * `lookback` bars before AND `lookback` bars after.
+   *
+   * A swing low occurs when a bar's low is lower than the lows of
+   * `lookback` bars before AND `lookback` bars after.
+   *
+   * Industry standard uses lookback=2 (5-bar pattern).
+   *
+   * @param input - Candles and optional lookback period
+   * @returns Detected swing points with trend analysis
+   */
+  public detectSwingPoints(
+    input: DetectSwingPointsInput,
+  ): DetectSwingPointsOutput {
+    const lookback = input.lookback ?? 2;
+    const highs = extractHighPrices(input.candles);
+    const lows = extractLowPrices(input.candles);
+
+    return detectSwingPoints(highs, lows, lookback);
   }
 }
 

--- a/src/server/indicators/swingPoints.spec.ts
+++ b/src/server/indicators/swingPoints.spec.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect } from '@jest/globals';
+import { detectSwingPoints } from './swingPoints';
+
+describe('swingPoints (Williams Fractal)', () => {
+  describe('detectSwingPoints', () => {
+    it('should detect swing high with default lookback (5-bar pattern)', () => {
+      // Pattern: lower highs around a peak
+      const highs = [100, 102, 105, 102, 100];
+      const lows = [98, 100, 103, 100, 98];
+
+      const result = detectSwingPoints(highs, lows);
+
+      expect(result.swingHighs).toHaveLength(1);
+      expect(result.swingHighs[0].index).toBe(2);
+      expect(result.swingHighs[0].price).toBe(105);
+      expect(result.swingHighs[0].type).toBe('high');
+    });
+
+    it('should detect swing low with default lookback (5-bar pattern)', () => {
+      // Pattern: higher lows around a trough
+      const highs = [105, 103, 100, 103, 105];
+      const lows = [103, 101, 98, 101, 103];
+
+      const result = detectSwingPoints(highs, lows);
+
+      expect(result.swingLows).toHaveLength(1);
+      expect(result.swingLows[0].index).toBe(2);
+      expect(result.swingLows[0].price).toBe(98);
+      expect(result.swingLows[0].type).toBe('low');
+    });
+
+    it('should detect multiple swing highs and lows', () => {
+      // Oscillating pattern with multiple swings
+      const highs = [100, 105, 110, 105, 100, 95, 100, 105, 110, 105, 100];
+      const lows = [95, 100, 105, 100, 95, 90, 95, 100, 105, 100, 95];
+
+      const result = detectSwingPoints(highs, lows);
+
+      expect(result.swingHighs.length).toBeGreaterThan(0);
+      expect(result.swingLows.length).toBeGreaterThan(0);
+    });
+
+    it('should detect swing points with custom lookback', () => {
+      // 3-bar pattern (lookback=1)
+      const highs = [100, 105, 100];
+      const lows = [98, 103, 98];
+
+      const result = detectSwingPoints(highs, lows, 1);
+
+      expect(result.swingHighs).toHaveLength(1);
+      expect(result.swingHighs[0].index).toBe(1);
+    });
+
+    it('should return empty arrays when no swings found', () => {
+      // Monotonically increasing - no swing highs possible
+      const highs = [100, 101, 102, 103, 104];
+      const lows = [98, 99, 100, 101, 102];
+
+      const result = detectSwingPoints(highs, lows);
+
+      expect(result.swingHighs).toHaveLength(0);
+      expect(result.swingLows).toHaveLength(0);
+    });
+
+    it('should return sideways trend when no swing points detected', () => {
+      const highs = [100, 101, 102, 103, 104];
+      const lows = [98, 99, 100, 101, 102];
+
+      const result = detectSwingPoints(highs, lows);
+
+      expect(result.trend).toBe('sideways');
+      expect(result.latestSwingHigh).toBeNull();
+      expect(result.latestSwingLow).toBeNull();
+    });
+
+    it('should identify uptrend when latest swing low is before latest swing high', () => {
+      // Uptrend: low formed first, then price rallied to form high
+      const highs = [100, 95, 90, 95, 100, 105, 110, 105, 100];
+      const lows = [95, 90, 85, 90, 95, 100, 105, 100, 95];
+
+      const result = detectSwingPoints(highs, lows);
+
+      // Swing low at index 2, swing high at index 6
+      expect(result.trend).toBe('uptrend');
+      expect(result.latestSwingLow?.index).toBeLessThan(
+        result.latestSwingHigh?.index ?? 0,
+      );
+    });
+
+    it('should identify downtrend when latest swing high is before latest swing low', () => {
+      // Downtrend: high formed first, then price declined to form low
+      const highs = [100, 105, 110, 105, 100, 95, 90, 95, 100];
+      const lows = [95, 100, 105, 100, 95, 90, 85, 90, 95];
+
+      const result = detectSwingPoints(highs, lows);
+
+      // Swing high at index 2, swing low at index 6
+      expect(result.trend).toBe('downtrend');
+      expect(result.latestSwingHigh?.index).toBeLessThan(
+        result.latestSwingLow?.index ?? 0,
+      );
+    });
+
+    it('should handle minimum candle count for default lookback', () => {
+      // Exactly 5 candles (minimum for lookback=2) with swing high
+      const highs = [100, 102, 105, 102, 100];
+      const lows = [98, 100, 103, 100, 98];
+
+      const result = detectSwingPoints(highs, lows);
+
+      // Should find the swing high at index 2
+      // Note: This data only produces a swing high, not a swing low
+      // (lows rise toward the center: 98, 100, 103 - not a trough pattern)
+      expect(result.swingHighs).toHaveLength(1);
+      expect(result.swingHighs[0].index).toBe(2);
+    });
+
+    it('should handle edge case with all equal prices', () => {
+      const highs = [100, 100, 100, 100, 100];
+      const lows = [95, 95, 95, 95, 95];
+
+      const result = detectSwingPoints(highs, lows);
+
+      // No swings when all prices are equal (strict inequality required)
+      expect(result.swingHighs).toHaveLength(0);
+      expect(result.swingLows).toHaveLength(0);
+      expect(result.trend).toBe('sideways');
+    });
+
+    it('should require strict inequality for swing detection', () => {
+      // Peak equal to neighbor - should NOT be detected as swing
+      const highs = [100, 105, 105, 105, 100];
+      const lows = [98, 103, 103, 103, 98];
+
+      const result = detectSwingPoints(highs, lows);
+
+      // Index 2 has high=105, but neighbors also have 105
+      // Strict inequality means this is NOT a swing high
+      expect(result.swingHighs).toHaveLength(0);
+    });
+  });
+
+  /**
+   * Integration tests with realistic market data patterns.
+   * These simulate real-world price action that traders encounter.
+   */
+  describe('realistic market scenarios', () => {
+    it('should detect swing points in typical BTC uptrend', () => {
+      // Realistic BTC/USD price action: higher highs and higher lows
+      const highs = [
+        42000,
+        42500,
+        43000,
+        42800,
+        42200, // Rally and pullback
+        42500,
+        43200,
+        43800,
+        43500,
+        43000, // Higher high
+        43300,
+        44000,
+        44500,
+        44200,
+        43800, // Another higher high
+      ];
+      const lows = [
+        41000,
+        41500,
+        42000,
+        41800,
+        41200, // First low
+        41500,
+        42200,
+        42800,
+        42500,
+        42000, // Higher low
+        42300,
+        43000,
+        43500,
+        43200,
+        42800, // Even higher low
+      ];
+
+      const result = detectSwingPoints(highs, lows);
+
+      // Should find swing points in this trending data
+      expect(result.swingHighs.length).toBeGreaterThan(0);
+      expect(result.swingLows.length).toBeGreaterThan(0);
+
+      // Verify structure of returned swing points
+      result.swingHighs.forEach((sp) => {
+        expect(sp).toHaveProperty('index');
+        expect(sp).toHaveProperty('price');
+        expect(sp.type).toBe('high');
+        expect(typeof sp.price).toBe('number');
+      });
+    });
+
+    it('should detect swing points in volatile crypto crash', () => {
+      // Sharp decline with bounces - common in crypto
+      const highs = [
+        60000,
+        58000,
+        55000,
+        57000,
+        54000, // Initial crash with dead cat bounce
+        52000,
+        50000,
+        53000,
+        49000,
+        48000, // Continued decline
+        50000,
+        52000,
+        51000,
+        49000,
+        47000, // Another bounce then lower
+      ];
+      const lows = [
+        58000, 55000, 52000, 54000, 51000, 49000, 47000, 50000, 46000, 45000,
+        47000, 49000, 48000, 46000, 44000,
+      ];
+
+      const result = detectSwingPoints(highs, lows);
+
+      // Verify algorithm handles volatile data
+      expect(Array.isArray(result.swingHighs)).toBe(true);
+      expect(Array.isArray(result.swingLows)).toBe(true);
+      expect(['uptrend', 'downtrend', 'sideways']).toContain(result.trend);
+    });
+
+    it('should identify key support/resistance levels from swing points', () => {
+      // Range-bound market with clear support and resistance
+      const highs = [
+        100,
+        102,
+        105,
+        103,
+        100, // First test of resistance at 105
+        98,
+        100,
+        104,
+        101,
+        98, // Retest
+        96,
+        99,
+        105,
+        102,
+        99, // Another test of 105
+      ];
+      const lows = [
+        95,
+        97,
+        100,
+        98,
+        95, // First test of support at 95
+        93,
+        95,
+        99,
+        96,
+        93, // Retest of support area
+        91,
+        94,
+        100,
+        97,
+        94,
+      ];
+
+      const result = detectSwingPoints(highs, lows);
+
+      // Swing highs should cluster around resistance (105)
+      // Swing lows should cluster around support (93-95)
+      expect(result.swingHighs.length).toBeGreaterThan(0);
+      const highPrices = result.swingHighs.map((sp) => sp.price);
+      expect(Math.max(...highPrices)).toBeGreaterThanOrEqual(104);
+    });
+  });
+
+  describe('response structure validation', () => {
+    it('should return correct response structure', () => {
+      const highs = [100, 105, 110, 105, 100, 95, 90, 95, 100];
+      const lows = [95, 100, 105, 100, 95, 90, 85, 90, 95];
+
+      const result = detectSwingPoints(highs, lows);
+
+      // Verify all required fields are present
+      expect(result).toHaveProperty('swingHighs');
+      expect(result).toHaveProperty('swingLows');
+      expect(result).toHaveProperty('latestSwingHigh');
+      expect(result).toHaveProperty('latestSwingLow');
+      expect(result).toHaveProperty('trend');
+
+      // Verify types
+      expect(Array.isArray(result.swingHighs)).toBe(true);
+      expect(Array.isArray(result.swingLows)).toBe(true);
+      expect(['uptrend', 'downtrend', 'sideways']).toContain(result.trend);
+    });
+
+    it('should set latestSwingHigh to last element of swingHighs array', () => {
+      const highs = [100, 105, 100, 95, 100, 106, 100];
+      const lows = [95, 100, 95, 90, 95, 101, 95];
+
+      const result = detectSwingPoints(highs, lows, 1);
+
+      expect(result.swingHighs.length).toBeGreaterThan(0);
+      expect(result.latestSwingHigh).toEqual(
+        result.swingHighs[result.swingHighs.length - 1],
+      );
+    });
+
+    it('should set latestSwingLow to last element of swingLows array', () => {
+      const highs = [105, 100, 105, 110, 105, 99, 105];
+      const lows = [100, 95, 100, 105, 100, 94, 100];
+
+      const result = detectSwingPoints(highs, lows, 1);
+
+      expect(result.swingLows.length).toBeGreaterThan(0);
+      expect(result.latestSwingLow).toEqual(
+        result.swingLows[result.swingLows.length - 1],
+      );
+    });
+
+    it('should return sideways when swing high and swing low have equal indices', () => {
+      // This pattern creates a swing high AND swing low at the same index (middle candle)
+      // The middle candle has the highest high AND the lowest low
+      const highs = [100, 110, 100]; // Middle high (110) is highest
+      const lows = [95, 85, 90]; // Middle low (85) is lowest
+
+      const result = detectSwingPoints(highs, lows, 1);
+
+      // Both swing high and swing low should be at index 1
+      expect(result.swingHighs).toHaveLength(1);
+      expect(result.swingLows).toHaveLength(1);
+      expect(result.swingHighs[0].index).toBe(1);
+      expect(result.swingLows[0].index).toBe(1);
+      // When indices are equal, trend should be sideways
+      expect(result.trend).toBe('sideways');
+    });
+  });
+});

--- a/src/server/indicators/swingPoints.ts
+++ b/src/server/indicators/swingPoints.ts
@@ -1,0 +1,177 @@
+/**
+ * Swing point type - high or low
+ */
+export type SwingPointType = 'high' | 'low';
+
+/**
+ * Single swing point (Williams Fractal)
+ */
+export interface SwingPoint {
+  readonly index: number;
+  readonly price: number;
+  readonly type: SwingPointType;
+}
+
+/**
+ * Trend direction based on swing points
+ */
+export type SwingTrend = 'uptrend' | 'downtrend' | 'sideways';
+
+/**
+ * Default lookback period for Williams Fractal (2 bars each side = 5-bar pattern)
+ */
+const DEFAULT_LOOKBACK = 2;
+
+/**
+ * Detect swing points using Williams Fractal method.
+ *
+ * Williams Fractal Definition:
+ * - Swing High: A bar where the high is higher than the highs of
+ *   `lookback` bars before AND `lookback` bars after
+ * - Swing Low: A bar where the low is lower than the lows of
+ *   `lookback` bars before AND `lookback` bars after
+ *
+ * Industry standard uses lookback=2 (5-bar pattern).
+ *
+ * @param highs - Array of high prices (oldest first, index 0 = oldest)
+ * @param lows - Array of low prices (oldest first, index 0 = oldest)
+ * @param lookback - Number of bars on each side to compare (default: 2)
+ * @returns Detected swing points with trend analysis
+ */
+export function detectSwingPoints(
+  highs: readonly number[],
+  lows: readonly number[],
+  lookback: number = DEFAULT_LOOKBACK,
+) {
+  const swingHighs = findSwingHighs(highs, lookback);
+  const swingLows = findSwingLows(lows, lookback);
+
+  const latestSwingHigh =
+    swingHighs.length > 0 ? swingHighs[swingHighs.length - 1] : null;
+  const latestSwingLow =
+    swingLows.length > 0 ? swingLows[swingLows.length - 1] : null;
+
+  const trend = determineTrend(latestSwingHigh, latestSwingLow);
+
+  return {
+    swingHighs,
+    swingLows,
+    latestSwingHigh,
+    latestSwingLow,
+    trend,
+  };
+}
+
+/**
+ * Find swing highs (Williams Fractal Up).
+ *
+ * A swing high occurs when a bar's high is strictly higher than
+ * the highs of `lookback` bars before AND after it.
+ */
+function findSwingHighs(
+  highs: readonly number[],
+  lookback: number,
+): SwingPoint[] {
+  const swingPoints: SwingPoint[] = [];
+
+  for (let i = lookback; i < highs.length - lookback; i++) {
+    if (isSwingHigh(highs, i, lookback)) {
+      swingPoints.push({
+        index: i,
+        price: highs[i],
+        type: 'high',
+      });
+    }
+  }
+
+  return swingPoints;
+}
+
+/**
+ * Find swing lows (Williams Fractal Down).
+ *
+ * A swing low occurs when a bar's low is strictly lower than
+ * the lows of `lookback` bars before AND after it.
+ */
+function findSwingLows(
+  lows: readonly number[],
+  lookback: number,
+): SwingPoint[] {
+  const swingPoints: SwingPoint[] = [];
+
+  for (let i = lookback; i < lows.length - lookback; i++) {
+    if (isSwingLow(lows, i, lookback)) {
+      swingPoints.push({
+        index: i,
+        price: lows[i],
+        type: 'low',
+      });
+    }
+  }
+
+  return swingPoints;
+}
+
+/**
+ * Check if bar at index is a swing high.
+ */
+function isSwingHigh(
+  highs: readonly number[],
+  index: number,
+  lookback: number,
+): boolean {
+  const currentHigh = highs[index];
+
+  for (let j = 1; j <= lookback; j++) {
+    if (currentHigh <= highs[index - j] || currentHigh <= highs[index + j]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Check if bar at index is a swing low.
+ */
+function isSwingLow(
+  lows: readonly number[],
+  index: number,
+  lookback: number,
+): boolean {
+  const currentLow = lows[index];
+
+  for (let j = 1; j <= lookback; j++) {
+    if (currentLow >= lows[index - j] || currentLow >= lows[index + j]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Determine trend based on which swing point occurred more recently.
+ *
+ * - Uptrend: Latest swing low occurred before latest swing high
+ *   (price made a low, then rallied to make a high)
+ * - Downtrend: Latest swing high occurred before latest swing low
+ *   (price made a high, then declined to make a low)
+ * - Sideways: Cannot determine (no swing points or equal indices)
+ */
+function determineTrend(
+  latestSwingHigh: SwingPoint | null,
+  latestSwingLow: SwingPoint | null,
+): SwingTrend {
+  if (!latestSwingHigh || !latestSwingLow) {
+    return 'sideways';
+  }
+
+  if (latestSwingHigh.index > latestSwingLow.index) {
+    return 'uptrend';
+  } else if (latestSwingLow.index > latestSwingHigh.index) {
+    return 'downtrend';
+  }
+
+  return 'sideways';
+}

--- a/src/server/tools/AnalysisToolRegistry.ts
+++ b/src/server/tools/AnalysisToolRegistry.ts
@@ -1,0 +1,79 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import * as z from 'zod';
+import type { TechnicalAnalysisService } from '../TechnicalAnalysisService';
+import { IndicatorType } from '../TechnicalAnalysis';
+import { Granularity } from '../ProductCandles';
+import { ToolRegistry } from './ToolRegistry';
+
+/**
+ * Registry for technical analysis MCP tools (1 tool).
+ *
+ * Provides the `analyze_technical_indicators` tool which combines
+ * candle fetching and indicator calculation server-side, reducing
+ * context usage by ~90-95%.
+ */
+export class AnalysisToolRegistry extends ToolRegistry {
+  constructor(
+    server: McpServer,
+    private readonly analysis: TechnicalAnalysisService,
+  ) {
+    super(server);
+  }
+
+  public register(): void {
+    this.server.registerTool(
+      'analyze_technical_indicators',
+      {
+        title: 'Analyze Technical Indicators',
+        description:
+          'Analyze technical indicators for a cryptocurrency product. ' +
+          'This tool fetches candle data and calculates indicators server-side, ' +
+          'returning only computed values to reduce context usage. ' +
+          'Supports 24 indicators across 6 categories: ' +
+          'Momentum (RSI, MACD, Stochastic, ADX, CCI, Williams %R, ROC), ' +
+          'Trend (SMA, EMA, Ichimoku, PSAR), ' +
+          'Volatility (Bollinger Bands, ATR, Keltner), ' +
+          'Volume (OBV, MFI, VWAP, Volume Profile), ' +
+          'Patterns (Candlestick, RSI Divergence, Chart Patterns, Swing Points), ' +
+          'Support/Resistance (Pivot Points, Fibonacci). ' +
+          'Pivot Points use daily candles (industry standard). ' +
+          'Fibonacci uses Williams Fractal swing detection (industry standard).',
+        inputSchema: {
+          productId: z
+            .string()
+            .describe('Product ID to analyze (e.g., "BTC-USD", "ETH-USD")'),
+          granularity: z
+            .nativeEnum(Granularity)
+            .describe(
+              'Candle granularity. Common choices: ' +
+                'FIFTEEN_MINUTE (intraday), ONE_HOUR (short-term), ONE_DAY (long-term)',
+            ),
+          candleCount: z
+            .number()
+            .int()
+            .min(5)
+            .max(300)
+            .optional()
+            .describe(
+              'Number of candles to analyze (default: 100, min: 5, max: 300). ' +
+                'More candles improve pattern detection but increase processing time.',
+            ),
+          indicators: z
+            .array(z.nativeEnum(IndicatorType))
+            .optional()
+            .describe(
+              `Optional list of specific indicators to calculate. ` +
+                `If omitted, all ${Object.keys(IndicatorType).length} indicators are calculated. ` +
+                `Categories: Momentum (rsi, macd, stochastic, adx, cci, williams_r, roc), ` +
+                `Trend (sma, ema, ichimoku, psar), ` +
+                `Volatility (bollinger_bands, atr, keltner), ` +
+                `Volume (obv, mfi, vwap, volume_profile), ` +
+                `Patterns (candlestick_patterns, rsi_divergence, chart_patterns, swing_points), ` +
+                `Support/Resistance (pivot_points, fibonacci).`,
+            ),
+        },
+      },
+      this.call(this.analysis.analyzeTechnicalIndicators.bind(this.analysis)),
+    );
+  }
+}

--- a/src/server/tools/IndicatorToolRegistry.ts
+++ b/src/server/tools/IndicatorToolRegistry.ts
@@ -25,7 +25,7 @@ function candlesSchema(minCount: number, description?: string) {
 }
 
 /**
- * Registry for technical indicator MCP tools (23 tools).
+ * Registry for technical indicator MCP tools (24 tools).
  */
 export class IndicatorToolRegistry extends ToolRegistry {
   constructor(
@@ -594,6 +594,34 @@ export class IndicatorToolRegistry extends ToolRegistry {
         },
       },
       this.call(this.indicators.detectChartPatterns.bind(this.indicators)),
+    );
+
+    this.server.registerTool(
+      'detect_swing_points',
+      {
+        title: 'Detect Swing Points (Williams Fractals)',
+        description:
+          'Detect swing highs and swing lows using Williams Fractal method. ' +
+          "A swing high occurs when a bar's high is higher than the surrounding bars. " +
+          "A swing low occurs when a bar's low is lower than the surrounding bars. " +
+          'Useful for identifying support/resistance levels, trend direction, and Fibonacci retracement points.',
+        inputSchema: {
+          candles: candlesSchema(
+            5,
+            'Array of candle data (minimum 5 for default lookback)',
+          ),
+          lookback: z
+            .number()
+            .int()
+            .min(1)
+            .max(10)
+            .optional()
+            .describe(
+              'Number of bars on each side to compare (default: 2, resulting in 5-bar pattern)',
+            ),
+        },
+      },
+      this.call(this.indicators.detectSwingPoints.bind(this.indicators)),
     );
   }
 

--- a/src/test/serviceMocks.ts
+++ b/src/test/serviceMocks.ts
@@ -12,6 +12,7 @@ import {
 import { ProductsService } from '@server/ProductsService';
 import { PublicService } from '@server/PublicService';
 import type { TechnicalIndicatorsService } from '@server/TechnicalIndicatorsService';
+import type { TechnicalAnalysisService } from '@server/TechnicalAnalysisService';
 import { jest } from '@jest/globals';
 
 // Mock the SDK services to avoid real API calls
@@ -277,6 +278,15 @@ export const mockTechnicalIndicatorsService: {
   calculatePivotPoints: jest.fn(),
   detectRsiDivergence: jest.fn(),
   detectChartPatterns: jest.fn(),
+  detectSwingPoints: jest.fn(),
+};
+
+export const mockTechnicalAnalysisService: {
+  [K in keyof TechnicalAnalysisService]: jest.MockedFunction<
+    TechnicalAnalysisService[K]
+  >;
+} = {
+  analyzeTechnicalIndicators: jest.fn(),
 };
 
 export function mockServices() {
@@ -319,6 +329,14 @@ export function mockServices() {
       TechnicalIndicatorsService: jest
         .fn()
         .mockImplementation(() => mockTechnicalIndicatorsService),
+    };
+  });
+
+  jest.mock('@server/TechnicalAnalysisService', () => {
+    return {
+      TechnicalAnalysisService: jest
+        .fn()
+        .mockImplementation(() => mockTechnicalAnalysisService),
     };
   });
 }


### PR DESCRIPTION
…ontext

Add server-side technical indicator analysis tool that fetches candles and calculates all indicators in a single call, reducing context usage by ~90-95%.

New features:
- analyze_technical_indicators tool (fetches candles + calculates 24 indicators)
- detect_swing_points tool (Williams Fractal for swing detection)
- TechnicalAnalysisService for orchestrating indicator calculation
- Aggregated trading signal (score, direction, confidence)

Architecture:
- IndicatorType enum for type-safe indicator selection
- SwingPointsResult named type for swing point detection
- mapApiCandlesToInput helper for candle mapping
- nativeEnum for Granularity and IndicatorType (consistent with other registries)
- Direct method binding in AnalysisToolRegistry (no wrapper function)

Implementation details:
- Pivot Points use daily OHLC from previous trading day (industry standard)
- Fibonacci uses Williams Fractal swing detection (industry standard)
- swingPoints.ts follows helper function pattern (accepts number[] arrays)
- All 24 indicators supported with proper signal interpretation

Documentation:
- Updated CLAUDE.md, IMPLEMENTED_TOOLS.md with tool counts (71 tools)
- Updated .claude/skills/coinbase-trading/ with new tools
- Updated .claude/rules/indicators.md checklist

All 416 tests pass with 100% coverage.