### PR TITLE
docs: add implementation plan for number type standardization

### DIFF
--- a/PLAN_NUMBER_TYPES.md
+++ b/PLAN_NUMBER_TYPES.md
@@ -1208,7 +1208,7 @@ npm run knip          # Unused exports
 ## 6. Commit Message
 
 ```
-refactor: standardize number types across MCP tools and services
+refactor(server): standardize number types across MCP tools and services
 
 BREAKING CHANGE: All MCP tool schemas now use z.number() instead of
 z.string() for numeric values (amounts, prices, OHLCV data).


### PR DESCRIPTION
Add detailed plan (v2) for standardizing number types across MCP tools
and services. The plan was reviewed by a senior code reviewer and
addresses YAGNI concerns while fulfilling all acceptance criteria.

Key decisions:
- Create service wrappers for all 11 Coinbase SDK services
- Use simple number conversion functions (4 functions in one file)
- Limit response mapping to candles only (needed for internal processing)
- Refactor ProductsService/PublicService from extends to delegation

This plan will be implemented in a separate commit.